### PR TITLE
feat(stylelint): enable `declaration-property-value-no-unknown`

### DIFF
--- a/packages/@d-zero/stylelint-config/base.js
+++ b/packages/@d-zero/stylelint-config/base.js
@@ -33,6 +33,11 @@ module.exports = {
 		'declaration-no-important': true,
 		'declaration-property-value-disallowed-list': null,
 		'declaration-property-value-allowed-list': null,
+		'declaration-property-value-no-unknown': {
+			ignoreProperties: {
+				'/.+/': '/calc\\s\\(/',
+			},
+		},
 		'font-family-name-quotes': 'always-where-required',
 		'font-family-no-duplicate-names': true,
 		'font-weight-notation': 'named-where-possible',


### PR DESCRIPTION
fixes #119

`calc`を含むと警告対象になるので、正規表現で除外対象にしている。