### PR TITLE
feat(stylelint-rules): コンポーネントルート禁止プロパティルールを追加

### DIFF
--- a/packages/@d-zero/stylelint-rules/src/index.ts
+++ b/packages/@d-zero/stylelint-rules/src/index.ts
@@ -1,10 +1,12 @@
 import component from './rules/component/index.js';
+import componentRootDisallowedProperties from './rules/component-root-disallowed-properties/index.js';
 import declarationValueTypeDisallowedList from './rules/declaration-value-type-disallowed-list/index.js';
 import preferIndividualTransformProperties from './rules/prefer-individual-transform-properties/index.js';
 import shorthandPropertyUseLogical from './rules/shorthand-property-use-logical/index.js';
 
 export default [
 	component,
+	componentRootDisallowedProperties,
 	declarationValueTypeDisallowedList,
 	preferIndividualTransformProperties,
 	shorthandPropertyUseLogical,

--- a/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/README.md
+++ b/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/README.md
@@ -1,0 +1,130 @@
+# @d-zero/component-root-disallowed-properties
+
+コンポーネントルート（ファイル名と一致するクラス名を持つルール）で特定のプロパティを禁止するStylelintルールです。
+
+## 動作
+
+**コンポーネントルートで禁止されているプロパティの使用をチェックします**
+
+- ファイル名と完全一致するクラス名を持つルール（コンポーネントルート）のみをチェック対象とします
+- コンポーネントの子要素（`__element` など）や、その他のルールではチェックしません
+- 疑似クラス（`:hover`など）を含むルール内の禁止プロパティもチェック対象とします
+- 疑似要素（`::before`など）を含むルール内の禁止プロパティはチェック対象外です
+
+## 禁止プロパティ
+
+以下のプロパティはコンポーネントルートで使用できません：
+
+### 幅・高さ関連
+
+- `width`, `inline-size`（`min-width`, `max-width`, `min-inline-size`, `max-inline-size` は許可）
+- `height`, `block-size`（`min-height`, `max-height`, `min-block-size`, `max-block-size` は許可）
+
+### マージン関連
+
+- `margin`
+- `margin-top`, `margin-right`, `margin-bottom`, `margin-left`
+- `margin-block`, `margin-inline`
+- `margin-block-start`, `margin-block-end`
+- `margin-inline-start`, `margin-inline-end`
+
+### インセット関連
+
+- `inset`
+- `inset-block`, `inset-inline`
+- `top`, `right`, `bottom`, `left`
+
+### 配置関連
+
+- `position: absolute`
+- `justify-self`, `align-self`, `place-self`
+
+### Flex関連
+
+- `flex`
+- `flex-grow`, `flex-shrink`, `flex-basis`
+
+### その他
+
+- `grid-area`
+- `float`
+- `clear`
+
+## 例
+
+```css
+/* button.css */
+
+/* ❌ NG: コンポーネントルートで width は禁止 */
+.button {
+	width: 100px;
+}
+
+/* ✅ OK: min-width, max-width, min-height, max-height は許可 */
+.button {
+	min-width: 100px;
+	max-width: 500px;
+	min-height: 50px;
+	max-height: 200px;
+}
+
+/* ✅ OK: 子要素では禁止プロパティを使用可能 */
+.button__text {
+	width: 100px;
+	margin: 10px;
+}
+
+/* ❌ NG: コンポーネントルートで margin は禁止 */
+.button {
+	margin: 10px;
+}
+
+/* ❌ NG: コンポーネントルートで position: absolute は禁止 */
+.button {
+	position: absolute;
+}
+
+/* ✅ OK: position: relative は許可 */
+.button {
+	position: relative;
+}
+```
+
+```scss
+/* _c-component.scss */
+
+/* ❌ NG: コンポーネントルートで width は禁止 */
+.c-component {
+	width: 100px;
+}
+
+/* ✅ OK: ネストされた子要素では禁止プロパティを使用可能 */
+.c-component {
+	&__element {
+		width: 100px;
+		margin: 10px;
+	}
+}
+
+/* ❌ NG: 疑似クラス内で禁止プロパティは禁止 */
+.c-component {
+	&:hover {
+		position: absolute;
+		width: 100px;
+	}
+}
+
+/* ✅ OK: 疑似要素内で禁止プロパティは許可 */
+.c-component {
+	&::before {
+		position: absolute;
+		width: 100px;
+	}
+}
+```
+
+## 特別なケース
+
+### c-content-main
+
+`c-content-main` クラスについては、特に `width` と `inline-size` の使用が絶対に禁止されています。幅はコンポーネントをラップする親のエレメントに指定する必要があります。

--- a/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/index.spec.ts
+++ b/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/index.spec.ts
@@ -1,0 +1,708 @@
+import stylelint from 'stylelint';
+import { describe, test, expect } from 'vitest';
+
+import rule from './index.js';
+
+const { lint } = stylelint;
+
+const config = (settings: Record<string, unknown> | boolean = true) => ({
+	plugins: [rule],
+	rules: {
+		// @ts-ignore
+		[rule.ruleName]: settings,
+	},
+});
+
+describe('component-root-disallowed-properties', () => {
+	describe('コンポーネントルートでの禁止プロパティチェック', () => {
+		describe('width, inline-size', () => {
+			test('width が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { width: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('width');
+			});
+
+			test('inline-size が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { inline-size: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('inline-size');
+			});
+
+			test('min-width は許可されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { min-width: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('max-width は許可されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { max-width: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('min-inline-size は許可されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { min-inline-size: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('max-inline-size は許可されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { max-inline-size: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+		});
+
+		describe('margin関連', () => {
+			test('margin が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { margin: 10px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('margin');
+			});
+
+			test('margin-top が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { margin-top: 10px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('margin-top');
+			});
+
+			test('margin-block が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { margin-block: 10px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('margin-block');
+			});
+		});
+
+		describe('height, block-size', () => {
+			test('height が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { height: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('height');
+			});
+
+			test('block-size が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { block-size: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('block-size');
+			});
+
+			test('min-height は許可されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { min-height: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('max-height は許可されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { max-height: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('min-block-size は許可されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { min-block-size: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('max-block-size は許可されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { max-block-size: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+		});
+
+		describe('inset関連', () => {
+			test('inset が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { inset: 0; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('inset');
+			});
+
+			test('top が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { top: 0; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('top');
+			});
+		});
+
+		describe('position: absolute', () => {
+			test('position: absolute が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { position: absolute; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('position: absolute');
+			});
+
+			test('position: relative は許可されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { position: relative; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+		});
+
+		describe('flex関連', () => {
+			test('flex が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { flex: 1; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('flex');
+			});
+
+			test('flex-grow が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { flex-grow: 1; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('flex-grow');
+			});
+		});
+
+		describe('その他の禁止プロパティ', () => {
+			test('justify-self が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { justify-self: center; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('justify-self');
+			});
+
+			test('grid-area が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { grid-area: header; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('grid-area');
+			});
+
+			test('float が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { float: left; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('float');
+			});
+
+			test('clear が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { clear: both; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('clear');
+			});
+		});
+
+		describe('c-content-main クラス', () => {
+			test('c-content-main で width が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: '_c-content-main.scss',
+					code: '.c-content-main { width: 100px; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('width');
+			});
+		});
+	});
+
+	describe('コンポーネントルート以外ではエラーが出ないこと', () => {
+		describe('コンポーネントの子要素', () => {
+			test('SCSS: __element で禁止プロパティが使用されていてもエラーが出ない', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: '_c-component.scss',
+					code: `.c-component {
+						color: red;
+					}
+					.c-component__element {
+						width: 100px;
+						margin: 10px;
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('CSS: __element で禁止プロパティが使用されていてもエラーが出ない', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						color: red;
+					}
+					.button__text {
+						width: 100px;
+						margin: 10px;
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+		});
+
+		describe('ネストされたルール', () => {
+			test('SCSS: 子要素（__element）内で禁止プロパティが使用されていてもエラーが出ない', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: '_c-component.scss',
+					code: `.c-component {
+						color: red;
+						&__element {
+							width: 100px;
+							margin: 10px;
+						}
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('SCSS: 疑似クラス（:hover）内で禁止プロパティが使用されている場合はエラーが出る', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: '_c-component.scss',
+					code: `.c-component {
+						color: red;
+						&:hover {
+							position: absolute;
+						}
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('position: absolute');
+			});
+		});
+
+		describe('ファイル名と一致しないクラス名', () => {
+			test('ファイル名と一致しないクラス名のルールで禁止プロパティが使用されていてもエラーが出ない', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						color: red;
+					}
+					.card {
+						width: 100px;
+						margin: 10px;
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+		});
+
+		describe('複数のルール', () => {
+			test('コンポーネントルート以外のルールで禁止プロパティが使用されていてもエラーが出ない', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						color: red;
+					}
+					.button__icon {
+						width: 16px;
+					}
+					.button__text {
+						margin: 10px;
+					}
+					.other-class {
+						position: absolute;
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+		});
+
+		describe('疑似クラスの禁止', () => {
+			test(':hover 内で禁止プロパティが使用されている場合はエラーが出る', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						&:hover {
+							width: 100px;
+						}
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('width');
+			});
+
+			test(':focus 内で禁止プロパティが使用されている場合はエラーが出る', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						&:focus {
+							margin: 10px;
+						}
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('margin');
+			});
+
+			test(':active 内で禁止プロパティが使用されている場合はエラーが出る', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						&:active {
+							height: 100px;
+						}
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('height');
+			});
+
+			test('複数の疑似クラスが組み合わさっている場合もエラーが出る', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						&:hover:focus {
+							position: absolute;
+						}
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('position: absolute');
+			});
+		});
+
+		describe('疑似要素の許可', () => {
+			test('::before 内で禁止プロパティが使用されていてもエラーが出ない', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						&::before {
+							width: 100px;
+							margin: 10px;
+							position: absolute;
+						}
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('::after 内で禁止プロパティが使用されていてもエラーが出ない', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						&::after {
+							height: 100px;
+							top: 0;
+						}
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('::first-line 内で禁止プロパティが使用されていてもエラーが出ない', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						&::first-line {
+							flex: 1;
+						}
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+		});
+
+		describe('疑似クラスと疑似要素の組み合わせ', () => {
+			test(':hover::before のような組み合わせの場合、疑似要素が含まれているためエラーが出ない', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: `.button {
+						&:hover::before {
+							width: 100px;
+							position: absolute;
+						}
+					}`,
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+		});
+	});
+});

--- a/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/index.spec.ts
+++ b/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/index.spec.ts
@@ -270,7 +270,7 @@ describe('component-root-disallowed-properties', () => {
 			});
 		});
 
-		describe('position: absolute', () => {
+		describe('position', () => {
 			test('position: absolute が禁止されている', async () => {
 				const {
 					// @ts-ignore
@@ -286,6 +286,36 @@ describe('component-root-disallowed-properties', () => {
 				expect(warnings[0].text).toContain('position: absolute');
 			});
 
+			test('position: fixed が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { position: fixed; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('position: fixed');
+			});
+
+			test('position: sticky が禁止されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { position: sticky; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0].text).toContain('position: sticky');
+			});
+
 			test('position: relative は許可されている', async () => {
 				const {
 					// @ts-ignore
@@ -293,6 +323,20 @@ describe('component-root-disallowed-properties', () => {
 				} = await lint({
 					codeFilename: 'button.css',
 					code: '.button { position: relative; }',
+					config: config({}),
+				});
+
+				expect(parseErrors).toHaveLength(0);
+				expect(warnings).toHaveLength(0);
+			});
+
+			test('position: static は許可されている', async () => {
+				const {
+					// @ts-ignore
+					results: [{ warnings, parseErrors }],
+				} = await lint({
+					codeFilename: 'button.css',
+					code: '.button { position: static; }',
 					config: config({}),
 				});
 

--- a/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/index.ts
+++ b/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/index.ts
@@ -9,7 +9,9 @@ import stylelint from 'stylelint';
 import { createRule } from '../../utils/create-rule.js';
 
 // 禁止プロパティのリスト
-const DISALLOWED_PROPERTIES = [
+// string: プロパティ名のみ（例: 'width', 'margin'）
+// { [propName: string]: string }: プロパティ名と値のペア（例: { position: 'absolute' }）
+const DISALLOWED_PROPERTIES: (string | { [propName: string]: string })[] = [
 	'width',
 	'inline-size',
 	'margin',
@@ -42,7 +44,10 @@ const DISALLOWED_PROPERTIES = [
 	'grid-area',
 	'float',
 	'clear',
-] as const;
+	{ position: 'absolute' },
+	{ position: 'fixed' },
+	{ position: 'sticky' },
+];
 
 // min-* と max-* が許可されるプロパティ
 const ALLOW_MIN_MAX_PREFIX = ['width', 'inline-size', 'height', 'block-size'] as const;
@@ -53,9 +58,30 @@ const ALLOW_MIN_MAX_PREFIX = ['width', 'inline-size', 'height', 'block-size'] as
  */
 function isDisallowedProperty(prop: string): boolean {
 	const normalizedProp = prop.toLowerCase();
-	return DISALLOWED_PROPERTIES.includes(
-		normalizedProp as (typeof DISALLOWED_PROPERTIES)[number],
-	);
+	return DISALLOWED_PROPERTIES.some((item) => {
+		if (typeof item === 'string') {
+			return item === normalizedProp;
+		}
+		return false;
+	});
+}
+
+/**
+ * プロパティと値の組み合わせが禁止されているかチェック
+ * @param prop
+ * @param value
+ */
+function isDisallowedPropertyValue(prop: string, value: string): boolean {
+	const normalizedProp = prop.toLowerCase();
+	const normalizedValue = value.toLowerCase().trim();
+	return DISALLOWED_PROPERTIES.some((item) => {
+		if (typeof item === 'object') {
+			return (
+				normalizedProp in item && item[normalizedProp]?.toLowerCase() === normalizedValue
+			);
+		}
+		return false;
+	});
 }
 
 /**
@@ -180,18 +206,17 @@ export default createRule<Options>({
 				for (const node of rule.nodes) {
 					if (node.type === 'decl') {
 						const prop = node.prop;
+						const value = node.value;
 
-						// position: absolute のチェック
-						if (prop.toLowerCase() === 'position') {
-							const value = node.value.toLowerCase().trim();
-							if (value === 'absolute') {
-								stylelint.utils.report({
-									result,
-									ruleName,
-									message: messages.rejected('position: absolute'),
-									node,
-								});
-							}
+						// プロパティと値の組み合わせが禁止されているかチェック
+						if (isDisallowedPropertyValue(prop, value)) {
+							const normalizedValue = value.toLowerCase().trim();
+							stylelint.utils.report({
+								result,
+								ruleName,
+								message: messages.rejected(`${prop}: ${normalizedValue}`),
+								node,
+							});
 							continue;
 						}
 

--- a/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/index.ts
+++ b/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/index.ts
@@ -49,9 +49,6 @@ const DISALLOWED_PROPERTIES: (string | { [propName: string]: string })[] = [
 	{ position: 'sticky' },
 ];
 
-// min-* と max-* が許可されるプロパティ
-const ALLOW_MIN_MAX_PREFIX = ['width', 'inline-size', 'height', 'block-size'] as const;
-
 /**
  * プロパティが禁止されているかチェック
  * @param prop
@@ -82,30 +79,6 @@ function isDisallowedPropertyValue(prop: string, value: string): boolean {
 		}
 		return false;
 	});
-}
-
-/**
- * min-* または max-* プレフィックスが許可されているかチェック
- * @param prop
- */
-function isAllowedMinMaxProperty(prop: string): boolean {
-	const normalizedProp = prop.toLowerCase();
-	return ALLOW_MIN_MAX_PREFIX.some(
-		(allowedProp) =>
-			normalizedProp === `min-${allowedProp}` || normalizedProp === `max-${allowedProp}`,
-	);
-}
-
-/**
- * プロパティが禁止されているかチェック（min-* / max-* の許可を考慮）
- * @param prop
- */
-function shouldReportProperty(prop: string): boolean {
-	// min-* または max-* が許可されている場合は報告しない
-	if (isAllowedMinMaxProperty(prop)) {
-		return false;
-	}
-	return isDisallowedProperty(prop);
 }
 
 /**
@@ -221,7 +194,7 @@ export default createRule<Options>({
 						}
 
 						// その他の禁止プロパティのチェック
-						if (shouldReportProperty(prop)) {
+						if (isDisallowedProperty(prop)) {
 							stylelint.utils.report({
 								result,
 								ruleName,

--- a/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/index.ts
+++ b/packages/@d-zero/stylelint-rules/src/rules/component-root-disallowed-properties/index.ts
@@ -1,0 +1,233 @@
+import type { Rule } from 'postcss';
+import type { Selector } from 'postcss-selector-parser';
+
+import path from 'node:path';
+
+import selectorParser from 'postcss-selector-parser';
+import stylelint from 'stylelint';
+
+import { createRule } from '../../utils/create-rule.js';
+
+// 禁止プロパティのリスト
+const DISALLOWED_PROPERTIES = [
+	'width',
+	'inline-size',
+	'margin',
+	'margin-top',
+	'margin-right',
+	'margin-bottom',
+	'margin-left',
+	'margin-block',
+	'margin-inline',
+	'margin-block-start',
+	'margin-block-end',
+	'margin-inline-start',
+	'margin-inline-end',
+	'height',
+	'block-size',
+	'inset',
+	'inset-block',
+	'inset-inline',
+	'top',
+	'right',
+	'bottom',
+	'left',
+	'justify-self',
+	'align-self',
+	'place-self',
+	'flex',
+	'flex-grow',
+	'flex-shrink',
+	'flex-basis',
+	'grid-area',
+	'float',
+	'clear',
+] as const;
+
+// min-* と max-* が許可されるプロパティ
+const ALLOW_MIN_MAX_PREFIX = ['width', 'inline-size', 'height', 'block-size'] as const;
+
+/**
+ * プロパティが禁止されているかチェック
+ * @param prop
+ */
+function isDisallowedProperty(prop: string): boolean {
+	const normalizedProp = prop.toLowerCase();
+	return DISALLOWED_PROPERTIES.includes(
+		normalizedProp as (typeof DISALLOWED_PROPERTIES)[number],
+	);
+}
+
+/**
+ * min-* または max-* プレフィックスが許可されているかチェック
+ * @param prop
+ */
+function isAllowedMinMaxProperty(prop: string): boolean {
+	const normalizedProp = prop.toLowerCase();
+	return ALLOW_MIN_MAX_PREFIX.some(
+		(allowedProp) =>
+			normalizedProp === `min-${allowedProp}` || normalizedProp === `max-${allowedProp}`,
+	);
+}
+
+/**
+ * プロパティが禁止されているかチェック（min-* / max-* の許可を考慮）
+ * @param prop
+ */
+function shouldReportProperty(prop: string): boolean {
+	// min-* または max-* が許可されている場合は報告しない
+	if (isAllowedMinMaxProperty(prop)) {
+		return false;
+	}
+	return isDisallowedProperty(prop);
+}
+
+/**
+ * ルールがコンポーネントルートかどうかを判定
+ * @param rule
+ * @param basename
+ */
+function isComponentRoot(rule: Rule, basename: string): boolean {
+	const ruleSelectors: Selector[] = [];
+	selectorParser((parsedRoot) => {
+		for (const node of parsedRoot.nodes) {
+			ruleSelectors.push(node);
+		}
+	}).processSync(rule.selector);
+
+	const [ruleFirstSelector] = ruleSelectors;
+	if (!ruleFirstSelector) {
+		return false;
+	}
+
+	for (const node of ruleFirstSelector.nodes) {
+		if (node.type === 'class') {
+			const className = node.value;
+
+			// ファイル名と完全一致するクラス名のみがコンポーネントルート
+			// CSSファイルの場合は __ で始まるクラスは子要素なので除外
+			if (className === basename) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+/**
+ * ルールのセレクタに疑似クラスが含まれているか判定
+ * @param rule
+ */
+function hasPseudoClass(rule: Rule): boolean {
+	let hasPseudo = false;
+	selectorParser((parsedRoot) => {
+		parsedRoot.walkPseudos((pseudo) => {
+			// 疑似クラスは : で始まる（疑似要素は :: で始まる）
+			if (pseudo.value.startsWith(':')) {
+				hasPseudo = true;
+			}
+		});
+	}).processSync(rule.selector);
+	return hasPseudo;
+}
+
+/**
+ * ルールのセレクタに疑似要素が含まれているか判定
+ * @param rule
+ */
+function hasPseudoElement(rule: Rule): boolean {
+	let hasPseudo = false;
+	selectorParser((parsedRoot) => {
+		parsedRoot.walkPseudos((pseudo) => {
+			// 疑似要素は :: で始まる
+			if (pseudo.value.startsWith('::')) {
+				hasPseudo = true;
+			}
+		});
+	}).processSync(rule.selector);
+	return hasPseudo;
+}
+
+type Options = Record<string, never>;
+
+export default createRule<Options>({
+	name: 'component-root-disallowed-properties',
+	rejected: (property: string) =>
+		`コンポーネントルートで "${property}" プロパティは禁止されています`,
+	rule: (ruleName, messages) => () => {
+		return (root, result) => {
+			const fileName = root.source?.input.file;
+
+			if (!fileName) {
+				return;
+			}
+
+			const ext = path.extname(fileName);
+			const originalBasename = path.basename(fileName, ext);
+
+			const basename = ['.scss', '.sass'].includes(ext)
+				? originalBasename.replace(/^_/, '')
+				: originalBasename;
+
+			const rules = root.nodes.filter((node): node is Rule => node.type === 'rule');
+
+			/**
+			 * ルール内の宣言をチェックする関数
+			 * @param rule
+			 */
+			const checkDeclarations = (rule: Rule) => {
+				for (const node of rule.nodes) {
+					if (node.type === 'decl') {
+						const prop = node.prop;
+
+						// position: absolute のチェック
+						if (prop.toLowerCase() === 'position') {
+							const value = node.value.toLowerCase().trim();
+							if (value === 'absolute') {
+								stylelint.utils.report({
+									result,
+									ruleName,
+									message: messages.rejected('position: absolute'),
+									node,
+								});
+							}
+							continue;
+						}
+
+						// その他の禁止プロパティのチェック
+						if (shouldReportProperty(prop)) {
+							stylelint.utils.report({
+								result,
+								ruleName,
+								message: messages.rejected(prop),
+								node,
+							});
+						}
+					} else if (node.type === 'rule') {
+						// ネストされたルールをチェック
+						// 疑似要素を含むルールはチェック対象から除外
+						if (hasPseudoElement(node)) {
+							continue;
+						}
+						// 疑似クラスを含むルールはチェック対象
+						if (hasPseudoClass(node)) {
+							checkDeclarations(node);
+						}
+					}
+				}
+			};
+
+			// 各ルールをチェック
+			for (const rule of rules) {
+				// コンポーネントルートかどうかを判定
+				if (!isComponentRoot(rule, basename)) {
+					continue;
+				}
+
+				// コンポーネントルート内の直接の子ノード（宣言）と疑似クラスを含むネストされたルールをチェック
+				checkDeclarations(rule);
+			}
+		};
+	},
+});


### PR DESCRIPTION
Issue #614 に対応し、コンポーネントルートで特定のプロパティを禁止する新しいStylelintルール component-root-disallowed-properties を追加。

## 変更内容

- コンポーネントルート（ファイル名と一致するクラス名）で禁止プロパティをチェック
- 疑似クラス（:hoverなど）内の禁止プロパティもチェック対象
- 疑似要素（::beforeなど）内はチェック対象外
- position: absolute, fixed, sticky を禁止対象に追加
- 禁止プロパティを string | { [propName: string]: string } 形式で管理

## 禁止プロパティ

- width, inline-size, height, block-size
- margin関連（margin, margin-top, margin-right, margin-bottom, margin-left, margin-block, margin-inline, margin-block-start, margin-block-end, margin-inline-start, margin-inline-end）
- inset関連（inset, inset-block, inset-inline, top, right, bottom, left）
- position: absolute, fixed, sticky
- justify-self, align-self, place-self
- flex関連（flex, flex-grow, flex-shrink, flex-basis）
- grid-area, float, clear

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new Stylelint rule `component-root-disallowed-properties` and integrates it into `src/index.ts`.
> 
> - Disallows root-level use of `width`/`inline-size`, `height`/`block-size`, all `margin*`, `inset*`/`top`/`right`/`bottom`/`left`, `flex*`, `justify-self`/`align-self`/`place-self`, `grid-area`, `float`, `clear`, and `position: absolute|fixed|sticky`; allows `min/max-*` variants
> - Targets only component root selectors whose class matches the file basename; checks inside pseudo-classes, ignores pseudo-elements and non-root/child selectors
> - Adds comprehensive tests in `index.spec.ts` and documentation in `README.md` with usage examples
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f7c78232a6cc33a61dbb9c0e5d102e510dcf8df. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->