### PR TITLE
feat(markuplint)!: upgrade markuplint to v5.0.0-alpha.3

### DIFF
--- a/packages/@d-zero/markuplint-config/base.js
+++ b/packages/@d-zero/markuplint-config/base.js
@@ -8,6 +8,14 @@ export default {
 		// img[src] に対する width, height 必須ルールを無効化
 		// width, height はビルド時に自動的に付与されるため問題なしとする
 		'performance/img-aspect-ratio': false,
+		'attr-order': ['id', 'class', 'role', { group: 'aria' }, { group: 'data' }],
+		'head-element-order': true,
+		'no-boolean-attr-value': true,
+		'no-default-value': true,
+		'no-use-event-handler-attr': true,
+		// browserslist設定がある場合にブラウザ未サポート要素・属性を検出
+		// @see https://github.com/markuplint/markuplint/issues/3328
+		'no-unsupported-features': true,
 		'd-zero/no-br': {
 			rules: {
 				'disallowed-element': {

--- a/packages/@d-zero/markuplint-config/base.js
+++ b/packages/@d-zero/markuplint-config/base.js
@@ -4,6 +4,10 @@
 export default {
 	extends: ['markuplint:recommended-static-html'],
 	rules: {
+		// markuplint:recommended-static-html (performance preset) の
+		// img[src] に対する width, height 必須ルールを無効化
+		// width, height はビルド時に自動的に付与されるため問題なしとする
+		'performance/img-aspect-ratio': false,
 		'disallowed-element': {
 			value: ['br'],
 			reason:
@@ -36,8 +40,6 @@ export default {
 		{
 			selector: 'img',
 			rules: {
-				// https://github.com/markuplint/markuplint/blob/c35e0beb5e14093a41cee7634221dbe7f7d577f9/packages/%40markuplint/config-presets/src/preset.performance.json#L25-L35 の設定を上書き
-				// width, height の指定は上書きされるため、省略可能になるが、ビルド時に自動的に付与されるため問題なしとする
 				'required-attr': {
 					value: 'alt',
 					reason:

--- a/packages/@d-zero/markuplint-config/base.js
+++ b/packages/@d-zero/markuplint-config/base.js
@@ -8,10 +8,14 @@ export default {
 		// img[src] に対する width, height 必須ルールを無効化
 		// width, height はビルド時に自動的に付与されるため問題なしとする
 		'performance/img-aspect-ratio': false,
-		'disallowed-element': {
-			value: ['br'],
-			reason:
-				'br要素は原則使用しません。代わりにCSSでスタイルを調整してください。使用する場合は理由が必要です。（D-ZERO独自ルール）',
+		'd-zero/no-br': {
+			rules: {
+				'disallowed-element': {
+					value: ['br'],
+					reason:
+						'br要素は原則使用しません。代わりにCSSでスタイルを調整してください。使用する場合は理由が必要です。（D-ZERO独自ルール）',
+				},
+			},
 		},
 	},
 	nodeRules: [
@@ -22,6 +26,7 @@ export default {
 			},
 		},
 		{
+			name: 'd-zero/html-allow-prefix-attr',
 			selector: 'html',
 			rules: {
 				// <html prefix="og: http://ogp.me/ns#">
@@ -38,6 +43,7 @@ export default {
 			},
 		},
 		{
+			name: 'd-zero/img-require-alt',
 			selector: 'img',
 			rules: {
 				'required-attr': {
@@ -48,6 +54,7 @@ export default {
 			},
 		},
 		{
+			name: 'd-zero/img-src-kebab-case',
 			selector:
 				'img:not([src^="data:"], [src^="blob:"], [src^="https://"], [src^="http://"], [src^="//"])',
 			rules: {
@@ -66,6 +73,7 @@ export default {
 			},
 		},
 		{
+			name: 'd-zero/media-src-kebab-case',
 			selector: 'video, audio, source',
 			rules: {
 				'invalid-attr': {
@@ -87,6 +95,7 @@ export default {
 			},
 		},
 		{
+			name: 'd-zero/a-href-convention',
 			selector: 'a',
 			rules: {
 				'required-attr': {
@@ -109,6 +118,7 @@ export default {
 			},
 		},
 		{
+			name: 'd-zero/button-require-command',
 			selector: 'button[type=button]:not([role]):not([popovertarget])',
 			rules: {
 				'required-attr': {
@@ -119,6 +129,7 @@ export default {
 			},
 		},
 		{
+			name: 'd-zero/button-prefer-commandfor',
 			selector: 'button[popovertarget]',
 			rules: {
 				'required-attr': {
@@ -129,6 +140,7 @@ export default {
 			},
 		},
 		{
+			name: 'd-zero/button-prefer-command-action',
 			selector: 'button[popovertargetaction]',
 			rules: {
 				'required-attr': {

--- a/packages/@d-zero/markuplint-config/package.json
+++ b/packages/@d-zero/markuplint-config/package.json
@@ -22,7 +22,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@markuplint/pug-parser": "4.6.23",
-		"markuplint": "4.14.0"
+		"@markuplint/pug-parser": "5.0.0-alpha.3",
+		"markuplint": "5.0.0-alpha.3"
 	}
 }

--- a/test/cli.spec.mjs
+++ b/test/cli.spec.mjs
@@ -172,10 +172,10 @@ describe('markuplint', () => {
 			'packages/@d-zero/markuplint-config/base.js',
 		);
 		expect(invalidNaming).toStrictEqual([
-			'test/fixtures/markuplint/image-naming-test.html:21:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
-			'test/fixtures/markuplint/image-naming-test.html:22:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
-			'test/fixtures/markuplint/image-naming-test.html:23:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
-			'test/fixtures/markuplint/image-naming-test.html:24:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
+			'test/fixtures/markuplint/image-naming-test.html:21:45 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
+			'test/fixtures/markuplint/image-naming-test.html:22:39 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
+			'test/fixtures/markuplint/image-naming-test.html:23:44 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
+			'test/fixtures/markuplint/image-naming-test.html:24:41 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
 		]);
 
 		const validNaming = await markuplint(
@@ -217,6 +217,25 @@ describe('markuplint', () => {
 			'test/fixtures/markuplint/button-command.html:102:2 The "button" element expects the "command" attribute (required-attr) [d-zero/button-prefer-command-action]',
 			'test/fixtures/markuplint/button-command.html:103:2 The "button" element expects the "command" attribute (required-attr) [d-zero/button-prefer-command-action]',
 			'test/fixtures/markuplint/button-command.html:104:2 The "button" element expects the "command" attribute (required-attr) [d-zero/button-prefer-command-action]',
+		]);
+	});
+
+	test('Attr Order', async () => {
+		const violations = await markuplint(
+			'test/fixtures/markuplint/attr-order-test.html',
+			'packages/@d-zero/markuplint-config/base.js',
+		);
+		expect(violations).toStrictEqual([
+			'test/fixtures/markuplint/attr-order-test.html:17:36 "id" should be before "type" (attr-order)',
+			'test/fixtures/markuplint/attr-order-test.html:18:23 "class" should be before "src" (attr-order)',
+			'test/fixtures/markuplint/attr-order-test.html:19:41 "class" should be before "name" (attr-order)',
+			'test/fixtures/markuplint/attr-order-test.html:20:26 "id" should be before "href" (attr-order)',
+			'test/fixtures/markuplint/attr-order-test.html:21:53 "id" should be before "data-value" (attr-order)',
+			'test/fixtures/markuplint/attr-order-test.html:11:38 The "tab" role requires an accessibility parent with the "tablist" role (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/attr-order-test.html:11:43 The "aria-selected" ARIA state is not global state (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/attr-order-test.html:14:33 The "menuitem" role requires an accessibility parent with one of the roles: "menu", "menubar", "menu > group", "menubar > group" (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/attr-order-test.html:20:43 The "menuitem" role requires an accessibility parent with one of the roles: "menu", "menubar", "menu > group", "menubar > group" (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/attr-order-test.html:17:2 The "button" element expects the "command" attribute (required-attr) [d-zero/button-require-command]',
 		]);
 	});
 });

--- a/test/cli.spec.mjs
+++ b/test/cli.spec.mjs
@@ -110,7 +110,8 @@ describe('markuplint', () => {
 		try {
 			const violations = JSON.parse(stdout);
 			const formatted = violations.map(
-				(v) => `${n(v.filePath)}:${v.line}:${v.col} ${v.message}`,
+				(v) =>
+					`${n(v.filePath)}:${v.line}:${v.col} ${v.message} (${v.ruleId})${v.name ? ` [${v.name}]` : ''}`,
 			);
 			return formatted;
 		} catch (error) {
@@ -124,32 +125,32 @@ describe('markuplint', () => {
 	test('CLI', async () => {
 		const violations = await markuplint('test/fixtures/markuplint/test.*');
 		expect(violations).toStrictEqual([
-			'test/fixtures/markuplint/test.pug:14:6 The "c-component__invalid-element-nesting" class name is unmatched with the below patterns: "/^c-component2__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!component2)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-component2[a-z0-9]*(?:-[a-z0-9]+)*$/"',
-			'test/fixtures/markuplint/test.pug:9:4 The "div" element is not allowed in the "span" element in this context',
-			'test/fixtures/markuplint/test.html:14:18 The "c-component__invalid-element-nesting" class name is unmatched with the below patterns: "/^c-component2__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!component2)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-component2[a-z0-9]*(?:-[a-z0-9]+)*$/"',
-			'test/fixtures/markuplint/test.html:26:3 The "br" element is disallowed',
-			'test/fixtures/markuplint/test.html:25:12 The "href" attribute is matched with the below disallowed patterns: /^javascript:/i',
-			'test/fixtures/markuplint/test.html:23:3 The "img" element expects the "alt" attribute',
-			'test/fixtures/markuplint/test.html:24:3 The "a" element expects the "href" attribute',
-			'test/fixtures/markuplint/test.html:9:9 The "div" element is not allowed in the "span" element in this context',
-			'test/fixtures/markuplint/test.html:23:3 Require accessible name',
-			'test/fixtures/markuplint/test.html:25:3 Require accessible name',
-			'test/fixtures/markuplint/test.html:1:1 Require the "h1" element',
-			'test/fixtures/markuplint/test.html:17:66 Illegal characters must escape in character reference',
+			'test/fixtures/markuplint/test.pug:14:6 The "c-component__invalid-element-nesting" class name is unmatched with the below patterns: "/^c-component2__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!component2)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-component2[a-z0-9]*(?:-[a-z0-9]+)*$/" (class-naming)',
+			'test/fixtures/markuplint/test.pug:9:4 The "div" element is not allowed in the "span" element in this context (permitted-contents) [html-standard/permitted-contents]',
+			'test/fixtures/markuplint/test.html:14:18 The "c-component__invalid-element-nesting" class name is unmatched with the below patterns: "/^c-component2__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!component2)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-component2[a-z0-9]*(?:-[a-z0-9]+)*$/" (class-naming)',
+			'test/fixtures/markuplint/test.html:9:9 The "div" element is not allowed in the "span" element in this context (permitted-contents) [html-standard/permitted-contents]',
+			'test/fixtures/markuplint/test.html:23:3 Require accessible name (require-accessible-name) [a11y/require-accessible-name]',
+			'test/fixtures/markuplint/test.html:25:3 Require accessible name (require-accessible-name) [a11y/require-accessible-name]',
+			'test/fixtures/markuplint/test.html:1:1 Require the "h1" element (required-h1) [a11y/required-h1]',
+			'test/fixtures/markuplint/test.html:17:66 Illegal characters must escape in character reference (character-reference) [static-html/character-reference]',
+			'test/fixtures/markuplint/test.html:26:3 The "br" element is disallowed (disallowed-element) [d-zero/no-br]',
+			'test/fixtures/markuplint/test.html:23:3 The "img" element expects the "alt" attribute (required-attr) [d-zero/img-require-alt]',
+			'test/fixtures/markuplint/test.html:24:3 The "a" element expects the "href" attribute (required-attr) [d-zero/a-href-convention/required-attr]',
+			'test/fixtures/markuplint/test.html:25:12 The "href" attribute is matched with the below disallowed patterns: /^javascript:/i (invalid-attr) [d-zero/a-href-convention/invalid-attr]',
 		]);
 	});
 
 	test('Extended Naming', async () => {
 		const normalConfig = await markuplint('test/fixtures/markuplint/extended-naming.*');
 		expect(normalConfig).toStrictEqual([
-			'test/fixtures/markuplint/extended-naming.pug:2:2 The "splide" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/"',
-			'test/fixtures/markuplint/extended-naming.pug:4:4 The "splide__track" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/"',
-			'test/fixtures/markuplint/extended-naming.pug:5:5 The "splide__list" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/"',
-			'test/fixtures/markuplint/extended-naming.pug:6:6 The "splide__slide" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/"',
-			'test/fixtures/markuplint/extended-naming.pug:8:6 The "splide__slide" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/"',
-			'test/fixtures/markuplint/extended-naming.pug:10:6 The "splide__slide" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/"',
-			'test/fixtures/markuplint/extended-naming.pug:12:4 The "splide__arrows" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/"',
-			'test/fixtures/markuplint/extended-naming.pug:15:29 The "splide__pagination" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/"',
+			'test/fixtures/markuplint/extended-naming.pug:2:2 The "splide" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/" (class-naming)',
+			'test/fixtures/markuplint/extended-naming.pug:4:4 The "splide__track" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/" (class-naming)',
+			'test/fixtures/markuplint/extended-naming.pug:5:5 The "splide__list" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/" (class-naming)',
+			'test/fixtures/markuplint/extended-naming.pug:6:6 The "splide__slide" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/" (class-naming)',
+			'test/fixtures/markuplint/extended-naming.pug:8:6 The "splide__slide" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/" (class-naming)',
+			'test/fixtures/markuplint/extended-naming.pug:10:6 The "splide__slide" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/" (class-naming)',
+			'test/fixtures/markuplint/extended-naming.pug:12:4 The "splide__arrows" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/" (class-naming)',
+			'test/fixtures/markuplint/extended-naming.pug:15:29 The "splide__pagination" class name is unmatched with the below patterns: "/^c-carousel__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!carousel)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-carousel[a-z0-9]*(?:-[a-z0-9]+)*$/" (class-naming)',
 		]);
 
 		const addedClassName = await markuplint(
@@ -171,10 +172,10 @@ describe('markuplint', () => {
 			'packages/@d-zero/markuplint-config/base.js',
 		);
 		expect(invalidNaming).toStrictEqual([
-			'test/fixtures/markuplint/image-naming-test.html:21:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/',
-			'test/fixtures/markuplint/image-naming-test.html:22:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/',
-			'test/fixtures/markuplint/image-naming-test.html:23:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/',
-			'test/fixtures/markuplint/image-naming-test.html:24:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/',
+			'test/fixtures/markuplint/image-naming-test.html:21:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
+			'test/fixtures/markuplint/image-naming-test.html:22:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
+			'test/fixtures/markuplint/image-naming-test.html:23:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
+			'test/fixtures/markuplint/image-naming-test.html:24:15 The "src" attribute is matched with the below disallowed patterns: /[A-Z\\s_]/ (invalid-attr) [d-zero/img-src-kebab-case]',
 		]);
 
 		const validNaming = await markuplint(
@@ -190,29 +191,32 @@ describe('markuplint', () => {
 			'packages/@d-zero/markuplint-config/base.js',
 		);
 		expect(violations).toStrictEqual([
-			'test/fixtures/markuplint/button-command.html:18:2 The "button" element expects the "command" attribute',
-			'test/fixtures/markuplint/button-command.html:101:2 The "button" element expects the "commandfor" attribute',
-			'test/fixtures/markuplint/button-command.html:102:2 The "button" element expects the "command" attribute',
-			'test/fixtures/markuplint/button-command.html:103:2 The "button" element expects the "command" attribute',
-			'test/fixtures/markuplint/button-command.html:104:2 The "button" element expects the "command" attribute',
-			'test/fixtures/markuplint/button-command.html:41:2 Detected perceptible nodes between the trigger and corresponding target',
-			'test/fixtures/markuplint/button-command.html:42:2 Detected perceptible nodes between the trigger and corresponding target',
-			'test/fixtures/markuplint/button-command.html:102:2 Detected perceptible nodes between the trigger and corresponding target',
-			'test/fixtures/markuplint/button-command.html:103:2 Detected perceptible nodes between the trigger and corresponding target',
-			'test/fixtures/markuplint/button-command.html:104:2 Detected perceptible nodes between the trigger and corresponding target',
-			'test/fixtures/markuplint/button-command.html:111:6 Detected perceptible nodes between the trigger and corresponding target',
-			'test/fixtures/markuplint/button-command.html:24:2 The accessible name from "aria-label" overrides "content"',
-			'test/fixtures/markuplint/button-command.html:47:2 The accessible name from "aria-label" overrides "content"',
-			'test/fixtures/markuplint/button-command.html:129:3 Require accessible name',
-			'test/fixtures/markuplint/button-command.html:110:2 The "dialog" element referenced by a "show-modal" command requires an element with the "autofocus" attribute',
-			'test/fixtures/markuplint/button-command.html:54:16 The "tab" role requires an accessibility parent with the "tablist" role',
-			'test/fixtures/markuplint/button-command.html:55:16 The "tab" role requires an accessibility parent with the "tablist" role',
-			'test/fixtures/markuplint/button-command.html:55:21 The "aria-selected" ARIA state is not global state',
-			'test/fixtures/markuplint/button-command.html:57:16 The "menuitem" role requires an accessibility parent with one of the roles: "menu", "menubar", "menu > group", "menubar > group"',
-			'test/fixtures/markuplint/button-command.html:58:16 The "option" role requires an accessibility parent with one of the roles: "listbox", "listbox > group"',
-			'test/fixtures/markuplint/button-command.html:63:16 The "button" role is the implicit role of the "button" element',
-			'test/fixtures/markuplint/button-command.html:66:16 The "tab" role requires an accessibility parent with the "tablist" role',
-			'test/fixtures/markuplint/button-command.html:88:16 The "tab" role requires an accessibility parent with the "tablist" role',
+			'test/fixtures/markuplint/button-command.html:41:2 Detected perceptible nodes between the trigger and corresponding target (neighbor-popovers) [a11y/neighbor-popovers]',
+			'test/fixtures/markuplint/button-command.html:42:2 Detected perceptible nodes between the trigger and corresponding target (neighbor-popovers) [a11y/neighbor-popovers]',
+			'test/fixtures/markuplint/button-command.html:102:2 Detected perceptible nodes between the trigger and corresponding target (neighbor-popovers) [a11y/neighbor-popovers]',
+			'test/fixtures/markuplint/button-command.html:103:2 Detected perceptible nodes between the trigger and corresponding target (neighbor-popovers) [a11y/neighbor-popovers]',
+			'test/fixtures/markuplint/button-command.html:104:2 Detected perceptible nodes between the trigger and corresponding target (neighbor-popovers) [a11y/neighbor-popovers]',
+			'test/fixtures/markuplint/button-command.html:111:6 Detected perceptible nodes between the trigger and corresponding target (neighbor-popovers) [a11y/neighbor-popovers]',
+			'test/fixtures/markuplint/button-command.html:24:2 The accessible name from "aria-label" overrides "content" (redundant-accessible-name) [a11y/redundant-accessible-name]',
+			'test/fixtures/markuplint/button-command.html:47:2 The accessible name from "aria-label" overrides "content" (redundant-accessible-name) [a11y/redundant-accessible-name]',
+			'test/fixtures/markuplint/button-command.html:129:3 Require accessible name (require-accessible-name) [a11y/require-accessible-name]',
+			'test/fixtures/markuplint/button-command.html:110:2 The "dialog" element referenced by a "show-modal" command requires an element with the "autofocus" attribute (require-dialog-autofocus) [a11y/require-dialog-autofocus]',
+			'test/fixtures/markuplint/button-command.html:54:16 The "tab" role requires an accessibility parent with the "tablist" role (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/button-command.html:55:16 The "tab" role requires an accessibility parent with the "tablist" role (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/button-command.html:55:21 The "aria-selected" ARIA state is not global state (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/button-command.html:57:16 The "menuitem" role requires an accessibility parent with one of the roles: "menu", "menubar", "menu > group", "menubar > group" (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/button-command.html:58:16 The "option" role requires an accessibility parent with one of the roles: "listbox", "listbox > group" (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/button-command.html:63:16 The "button" role is the implicit role of the "button" element (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/button-command.html:66:16 The "tab" role requires an accessibility parent with the "tablist" role (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/button-command.html:88:16 The "tab" role requires an accessibility parent with the "tablist" role (wai-aria) [a11y/wai-aria]',
+			'test/fixtures/markuplint/button-command.html:18:2 The "button" element expects the "command" attribute (required-attr) [d-zero/button-require-command]',
+			'test/fixtures/markuplint/button-command.html:101:2 The "button" element expects the "commandfor" attribute (required-attr) [d-zero/button-prefer-commandfor]',
+			'test/fixtures/markuplint/button-command.html:102:2 The "button" element expects the "commandfor" attribute (required-attr) [d-zero/button-prefer-commandfor]',
+			'test/fixtures/markuplint/button-command.html:103:2 The "button" element expects the "commandfor" attribute (required-attr) [d-zero/button-prefer-commandfor]',
+			'test/fixtures/markuplint/button-command.html:104:2 The "button" element expects the "commandfor" attribute (required-attr) [d-zero/button-prefer-commandfor]',
+			'test/fixtures/markuplint/button-command.html:102:2 The "button" element expects the "command" attribute (required-attr) [d-zero/button-prefer-command-action]',
+			'test/fixtures/markuplint/button-command.html:103:2 The "button" element expects the "command" attribute (required-attr) [d-zero/button-prefer-command-action]',
+			'test/fixtures/markuplint/button-command.html:104:2 The "button" element expects the "command" attribute (required-attr) [d-zero/button-prefer-command-action]',
 		]);
 	});
 });

--- a/test/cli.spec.mjs
+++ b/test/cli.spec.mjs
@@ -126,16 +126,16 @@ describe('markuplint', () => {
 		expect(violations).toStrictEqual([
 			'test/fixtures/markuplint/test.pug:14:6 The "c-component__invalid-element-nesting" class name is unmatched with the below patterns: "/^c-component2__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!component2)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-component2[a-z0-9]*(?:-[a-z0-9]+)*$/"',
 			'test/fixtures/markuplint/test.pug:9:4 The "div" element is not allowed in the "span" element in this context',
-			'test/fixtures/markuplint/test.html:17:66 Illegal characters must escape in character reference',
 			'test/fixtures/markuplint/test.html:14:18 The "c-component__invalid-element-nesting" class name is unmatched with the below patterns: "/^c-component2__[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-(?!component2)[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/", "/^c-component2[a-z0-9]*(?:-[a-z0-9]+)*$/"',
 			'test/fixtures/markuplint/test.html:26:3 The "br" element is disallowed',
 			'test/fixtures/markuplint/test.html:25:12 The "href" attribute is matched with the below disallowed patterns: /^javascript:/i',
+			'test/fixtures/markuplint/test.html:23:3 The "img" element expects the "alt" attribute',
+			'test/fixtures/markuplint/test.html:24:3 The "a" element expects the "href" attribute',
 			'test/fixtures/markuplint/test.html:9:9 The "div" element is not allowed in the "span" element in this context',
 			'test/fixtures/markuplint/test.html:23:3 Require accessible name',
 			'test/fixtures/markuplint/test.html:25:3 Require accessible name',
-			'test/fixtures/markuplint/test.html:23:3 The "img" element expects the "alt" attribute',
-			'test/fixtures/markuplint/test.html:24:3 The "a" element expects the "href" attribute',
 			'test/fixtures/markuplint/test.html:1:1 Require the "h1" element',
+			'test/fixtures/markuplint/test.html:17:66 Illegal characters must escape in character reference',
 		]);
 	});
 
@@ -190,21 +190,29 @@ describe('markuplint', () => {
 			'packages/@d-zero/markuplint-config/base.js',
 		);
 		expect(violations).toStrictEqual([
-			'test/fixtures/markuplint/button-command.html:27:17 The "btn" class name is unmatched with the below patterns: "/^c-(?<ComponentName>[a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/"',
-			'test/fixtures/markuplint/button-command.html:45:58 The "btn" class name is unmatched with the below patterns: "/^c-(?<ComponentName>[a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/"',
-			'test/fixtures/markuplint/button-command.html:102:2 Detected perceptible nodes between the trigger and corresponding target',
-			'test/fixtures/markuplint/button-command.html:103:2 Detected perceptible nodes between the trigger and corresponding target',
-			'test/fixtures/markuplint/button-command.html:104:2 Detected perceptible nodes between the trigger and corresponding target',
-			'test/fixtures/markuplint/button-command.html:111:6 Detected perceptible nodes between the trigger and corresponding target',
-			'test/fixtures/markuplint/button-command.html:110:2 Require accessible name',
-			'test/fixtures/markuplint/button-command.html:129:3 Require accessible name',
 			'test/fixtures/markuplint/button-command.html:18:2 The "button" element expects the "command" attribute',
 			'test/fixtures/markuplint/button-command.html:101:2 The "button" element expects the "commandfor" attribute',
 			'test/fixtures/markuplint/button-command.html:102:2 The "button" element expects the "command" attribute',
 			'test/fixtures/markuplint/button-command.html:103:2 The "button" element expects the "command" attribute',
 			'test/fixtures/markuplint/button-command.html:104:2 The "button" element expects the "command" attribute',
+			'test/fixtures/markuplint/button-command.html:41:2 Detected perceptible nodes between the trigger and corresponding target',
+			'test/fixtures/markuplint/button-command.html:42:2 Detected perceptible nodes between the trigger and corresponding target',
+			'test/fixtures/markuplint/button-command.html:102:2 Detected perceptible nodes between the trigger and corresponding target',
+			'test/fixtures/markuplint/button-command.html:103:2 Detected perceptible nodes between the trigger and corresponding target',
+			'test/fixtures/markuplint/button-command.html:104:2 Detected perceptible nodes between the trigger and corresponding target',
+			'test/fixtures/markuplint/button-command.html:111:6 Detected perceptible nodes between the trigger and corresponding target',
+			'test/fixtures/markuplint/button-command.html:24:2 The accessible name from "aria-label" overrides "content"',
+			'test/fixtures/markuplint/button-command.html:47:2 The accessible name from "aria-label" overrides "content"',
+			'test/fixtures/markuplint/button-command.html:129:3 Require accessible name',
+			'test/fixtures/markuplint/button-command.html:110:2 The "dialog" element referenced by a "show-modal" command requires an element with the "autofocus" attribute',
+			'test/fixtures/markuplint/button-command.html:54:16 The "tab" role requires an accessibility parent with the "tablist" role',
+			'test/fixtures/markuplint/button-command.html:55:16 The "tab" role requires an accessibility parent with the "tablist" role',
 			'test/fixtures/markuplint/button-command.html:55:21 The "aria-selected" ARIA state is not global state',
+			'test/fixtures/markuplint/button-command.html:57:16 The "menuitem" role requires an accessibility parent with one of the roles: "menu", "menubar", "menu > group", "menubar > group"',
+			'test/fixtures/markuplint/button-command.html:58:16 The "option" role requires an accessibility parent with one of the roles: "listbox", "listbox > group"',
 			'test/fixtures/markuplint/button-command.html:63:16 The "button" role is the implicit role of the "button" element',
+			'test/fixtures/markuplint/button-command.html:66:16 The "tab" role requires an accessibility parent with the "tablist" role',
+			'test/fixtures/markuplint/button-command.html:88:16 The "tab" role requires an accessibility parent with the "tablist" role',
 		]);
 	});
 });

--- a/test/fixtures/markuplint/attr-order-test.html
+++ b/test/fixtures/markuplint/attr-order-test.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Attr Order Test</title>
+</head>
+<body>
+	<h1>Attribute Order Tests</h1>
+
+	<!-- Should PASS: correct order (id > class > role > aria > data > specific) -->
+	<button id="btn1" class="btn" role="tab" aria-selected="true" data-index="0" type="button">Correct</button>
+	<img id="hero" class="img" alt="Hero" src="hero.jpg" />
+	<input id="search" class="input" aria-label="Search" data-type="search" name="q" type="search">
+	<a id="link" class="nav" role="menuitem" aria-current="page" href="/">Home</a>
+
+	<!-- Should ERROR: wrong order -->
+	<button type="button" class="btn" id="btn2">type before class and id</button>
+	<img src="photo.jpg" class="img" alt="Photo" />
+	<input name="email" aria-label="Email" class="input" type="email">
+	<a href="/" class="nav" id="link2" role="menuitem">href before class and id</a>
+	<div data-value="1" aria-hidden="true" class="box" id="box1">data before aria, class, id</div>
+</body>
+</html>

--- a/test/fixtures/markuplint/button-command.html
+++ b/test/fixtures/markuplint/button-command.html
@@ -24,7 +24,7 @@
 	<button aria-label="Action">With aria-label</button>
 
 	<!-- Button with class/id but no command -->
-	<button class="btn" id="my-button">With class and id</button>
+	<button id="my-button" class="btn">With class and id</button>
 
 	<!-- Form buttons OUTSIDE of form element -->
 	<button type="submit">Submit outside form</button>
@@ -35,16 +35,16 @@
 	     ======================================== -->
 
 	<!-- Basic command usage -->
-	<button commandfor="dialog" command="show-modal">Open Dialog</button>
-	<button commandfor="dialog" command="close">Close Dialog</button>
-	<button commandfor="popover" command="show-popover">Show Popover</button>
-	<button commandfor="popover" command="hide-popover">Hide Popover</button>
-	<button commandfor="details" command="toggle-popover">Toggle Details</button>
+	<button command="show-modal" commandfor="dialog">Open Dialog</button>
+	<button command="close" commandfor="dialog">Close Dialog</button>
+	<button command="show-popover" commandfor="popover">Show Popover</button>
+	<button command="hide-popover" commandfor="popover">Hide Popover</button>
+	<button command="toggle-popover" commandfor="details">Toggle Details</button>
 
 	<!-- Command with other attributes -->
-	<button commandfor="dialog" command="show-modal" class="btn">With class</button>
-	<button commandfor="dialog" command="show-modal" disabled>Disabled with command</button>
-	<button commandfor="dialog" command="show-modal" aria-label="Open">With aria</button>
+	<button class="btn" command="show-modal" commandfor="dialog">With class</button>
+	<button command="show-modal" commandfor="dialog" disabled>Disabled with command</button>
+	<button aria-label="Open" command="show-modal" commandfor="dialog">With aria</button>
 
 	<!-- ========================================
 	     Should PASS: Role exceptions
@@ -77,21 +77,21 @@
 	</form>
 
 	<!-- With form attribute referencing external form -->
-	<button type="submit" form="external-form">Submit for external form</button>
-	<button type="reset" form="external-form">Reset for external form</button>
+	<button form="external-form" type="submit">Submit for external form</button>
+	<button form="external-form" type="reset">Reset for external form</button>
 
 	<!-- ========================================
 	     Edge cases: Multiple attributes
 	     ======================================== -->
 
 	<!-- Role takes precedence (should pass) -->
-	<button role="tab" commandfor="dialog" command="show-modal">Role + Command</button>
+	<button role="tab" command="show-modal" commandfor="dialog">Role + Command</button>
 
 	<!-- Submit type takes precedence (should pass) -->
-	<button type="submit" commandfor="dialog" command="show-modal">Submit + Command</button>
+	<button command="show-modal" commandfor="dialog" type="submit">Submit + Command</button>
 
 	<!-- Reset type takes precedence (should pass) -->
-	<button type="reset" commandfor="dialog" command="show-modal">Reset + Command</button>
+	<button command="show-modal" commandfor="dialog" type="reset">Reset + Command</button>
 
 	<!-- ========================================
 	     Popovertarget attribute (Modern HTML)
@@ -109,7 +109,7 @@
 
 	<dialog id="dialog">
 		<p>Dialog content</p>
-		<button commandfor="dialog" command="close">Close</button>
+		<button command="close" commandfor="dialog">Close</button>
 	</dialog>
 
 	<div id="popover" popover>
@@ -126,7 +126,7 @@
 	</div>
 
 	<form id="external-form">
-		<input type="text" name="name">
+		<input name="name">
 	</form>
 </body>
 </html>

--- a/test/fixtures/markuplint/extended-naming.pug
+++ b/test/fixtures/markuplint/extended-naming.pug
@@ -4,11 +4,11 @@
 			.splide__track
 				.splide__list
 					.splide__slide
-						img(src="path/to/image01.jpg" alt="image01")
+						img(alt="image01" src="path/to/image01.jpg")
 					.splide__slide
-						img(src="path/to/image02.jpg" alt="image02")
+						img(alt="image02" src="path/to/image02.jpg")
 					.splide__slide
-						img(src="path/to/image03.jpg" alt="image03")
+						img(alt="image03" src="path/to/image03.jpg")
 			.splide__arrows.c-carousel__arrows
 		.c-carousel__control
 			button.c-carousel__control-prev(aria-label="Previous")

--- a/test/fixtures/markuplint/image-naming-test.html
+++ b/test/fixtures/markuplint/image-naming-test.html
@@ -8,19 +8,19 @@
     <h1>Image Naming Test</h1>
 
     <!-- Valid image file names -->
-    <img src="images/hero-banner.jpg" alt="Hero banner" />
-    <img src="assets/icons/search-icon.png" alt="Search icon" />
-    <img src="media/product-image-01.webp" alt="Product image" />
-    <img src="data:image/png;base64,XXXX" alt="Data URI image" />
-    <img src="blob:XXXX" alt="Blob image" />
-    <img src="https://XXXX" alt="HTTPS image" />
-    <img src="http://XXXX" alt="HTTP image" />
-    <img src="//XXXX" alt="Protocol-relative image" />
+    <img alt="Hero banner" src="images/hero-banner.jpg" />
+    <img alt="Search icon" src="assets/icons/search-icon.png" />
+    <img alt="Product image" src="media/product-image-01.webp" />
+    <img alt="Data URI image" src="data:image/png;base64,XXXX" />
+    <img alt="Blob image" src="blob:XXXX" />
+    <img alt="HTTPS image" src="https://XXXX" />
+    <img alt="HTTP image" src="http://XXXX" />
+    <img alt="Protocol-relative image" src="//XXXX" />
 
     <!-- Invalid image file names - should trigger errors -->
-    <img src="images/Hero Banner.jpg" alt="Hero banner with spaces" />
-    <img src="assets/ProductImage.PNG" alt="Uppercase letters" />
-    <img src="images/file_name.jpg" alt="Underscore in filename" />
-    <img src="assets/image.JPEG" alt="Uppercase extension" />
+    <img alt="Hero banner with spaces" src="images/Hero Banner.jpg" />
+    <img alt="Uppercase letters" src="assets/ProductImage.PNG" />
+    <img alt="Underscore in filename" src="images/file_name.jpg" />
+    <img alt="Uppercase extension" src="assets/image.JPEG" />
 </body>
 </html>

--- a/test/fixtures/markuplint/test.html
+++ b/test/fixtures/markuplint/test.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta content="width=device-width, initial-scale=1.0" name="viewport" />
 		<title>Document</title>
 	</head>
 	<body>

--- a/test/fixtures/markuplint/test.pug
+++ b/test/fixtures/markuplint/test.pug
@@ -2,7 +2,7 @@ doctype html
 html(lang="en")
 	head
 		meta(charset="UTF-8")
-		meta(name="viewport" content="width=device-width, initial-scale=1.0")
+		meta(content="width=device-width, initial-scale=1.0" name="viewport")
 		title Document
 	body
 		span

--- a/test/fixtures/markuplint/valid-image-naming.html
+++ b/test/fixtures/markuplint/valid-image-naming.html
@@ -8,11 +8,11 @@
     <h1>Valid Image Names</h1>
     
     <!-- All valid image file names - should pass -->
-    <img src="images/hero-banner.jpg" alt="Hero banner" />
-    <img src="assets/icons/search-icon.png" alt="Search icon" />
-    <img src="media/product-image-01.webp" alt="Product image" />
-    <img src="photos/team-member-photo.jpg" alt="Team member" />
-    <img src="icons/star.svg" alt="Star icon" />
-    <img src="thumbnails/thumb-001.gif" alt="Thumbnail" />
+    <img alt="Hero banner" src="images/hero-banner.jpg" />
+    <img alt="Search icon" src="assets/icons/search-icon.png" />
+    <img alt="Product image" src="media/product-image-01.webp" />
+    <img alt="Team member" src="photos/team-member-photo.jpg" />
+    <img alt="Star icon" src="icons/star.svg" />
+    <img alt="Thumbnail" src="thumbnails/thumb-001.gif" />
 </body>
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,8 +1083,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@d-zero/markuplint-config@workspace:packages/@d-zero/markuplint-config"
   dependencies:
-    "@markuplint/pug-parser": "npm:4.6.23"
-    markuplint: "npm:4.14.0"
+    "@markuplint/pug-parser": "npm:5.0.0-alpha.3"
+    markuplint: "npm:5.0.0-alpha.3"
   languageName: unknown
   linkType: soft
 
@@ -2025,298 +2025,228 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@markuplint/cli-utils@npm:4.4.13":
-  version: 4.4.13
-  resolution: "@markuplint/cli-utils@npm:4.4.13"
+"@markuplint/cli-utils@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/cli-utils@npm:5.0.0-alpha.3"
   dependencies:
     detect-installed: "npm:2.0.4"
     eastasianwidth: "npm:0.3.0"
     enquirer: "npm:2.4.1"
-    has-yarn: "npm:3.0.0"
+    has-yarn: "npm:4.0.0"
     picocolors: "npm:1.1.1"
     strip-ansi: "npm:7.1.2"
-  checksum: 10c0/3d14a1e8b8e9de275a157a9c92d4db76c9a0eb40da268891b4cddc987fd8a7b614b676ab6bf13186c21adedc61273df8b1860cbd3f803a57b53d6623b5c72027
+  checksum: 10c0/602e3a05009b698403bb23d13e01ef46426fff57214bdacb0dbbc03e91d948f5c5565d619aa7ec80422ecbeefa0ddf306f85c4564982471c749ae3700db26fcf
   languageName: node
   linkType: hard
 
-"@markuplint/config-presets@npm:4.5.13":
-  version: 4.5.13
-  resolution: "@markuplint/config-presets@npm:4.5.13"
-  checksum: 10c0/ebe52fd896c7952327eb7d272cf5a25602689880ad326a5797e3137af887fb267878e5cab910c2945eb4c767b14cde453185f4a00a58f687908e6b0d99ed3d34
+"@markuplint/config-presets@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/config-presets@npm:5.0.0-alpha.3"
+  checksum: 10c0/8287584f3901cae0ec7afbb8434d65c3b5db5ac7c59b334e08a27b476fcb17845a9a311c0c2ee4cd7c633a697d8b27462754c9aa8ec4a98e499b5541703cbabc
   languageName: node
   linkType: hard
 
-"@markuplint/file-resolver@npm:4.9.17":
-  version: 4.9.17
-  resolution: "@markuplint/file-resolver@npm:4.9.17"
+"@markuplint/file-resolver@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/file-resolver@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/html-parser": "npm:4.6.22"
-    "@markuplint/ml-ast": "npm:4.4.10"
-    "@markuplint/ml-config": "npm:4.8.14"
-    "@markuplint/ml-core": "npm:4.13.2"
-    "@markuplint/ml-spec": "npm:4.10.1"
-    "@markuplint/parser-utils": "npm:4.8.10"
-    "@markuplint/selector": "npm:4.7.7"
-    "@markuplint/shared": "npm:4.4.12"
+    "@markuplint/html-parser": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-ast": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-config": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-core": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-spec": "npm:5.0.0-alpha.3"
+    "@markuplint/parser-utils": "npm:5.0.0-alpha.3"
+    "@markuplint/selector": "npm:5.0.0-alpha.3"
+    "@markuplint/shared": "npm:5.0.0-alpha.3"
     cosmiconfig: "npm:9.0.0"
     debug: "npm:4.4.3"
-    glob: "npm:11.0.3"
+    glob: "npm:13.0.6"
     ignore: "npm:7.0.5"
     import-meta-resolve: "npm:4.2.0"
     jsonc: "npm:2.0.0"
-    minimatch: "npm:10.0.3"
-  checksum: 10c0/eca35529e10ab5cee4ac79b0c47c55101a42852c589d576d7b89f9f6e1ce5f4a1009c913911c220e61e0bee232547227ed631e1e96ac986162107e705b327bec
+    minimatch: "npm:10.2.4"
+  checksum: 10c0/c1baf99b87af9e9a5dcde962cfe722faa77d477ed6fc2911553eb140442dafe342a329b6cb07eaf4755fdeb783f7d95498bf10a831a6a1ce35f7e50081689a16
   languageName: node
   linkType: hard
 
-"@markuplint/html-parser@npm:4.6.22":
-  version: 4.6.22
-  resolution: "@markuplint/html-parser@npm:4.6.22"
+"@markuplint/html-parser@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/html-parser@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/ml-ast": "npm:4.4.10"
-    "@markuplint/parser-utils": "npm:4.8.10"
+    "@markuplint/ml-ast": "npm:5.0.0-alpha.3"
+    "@markuplint/parser-utils": "npm:5.0.0-alpha.3"
     parse5: "npm:8.0.0"
-    type-fest: "npm:4.41.0"
-  checksum: 10c0/43c42e17a8d4de9309afb12996e063a38d0a4926c2cf3183a17cbc66609e420a8f0f64590fe6d3c6aa27a4d476aa3c3f14ac73ffeccdd8f9e5279b5a4dcb04a3
+    type-fest: "npm:5.4.4"
+  checksum: 10c0/d5646a200ab9022f223070550f8807dbdb14ee80820df9c12389630d3ff321e58bd17924113b6e992ffa25b892f2b807a1240f04eee38d33b54aa305e19df80e
   languageName: node
   linkType: hard
 
-"@markuplint/html-parser@npm:4.6.23":
-  version: 4.6.23
-  resolution: "@markuplint/html-parser@npm:4.6.23"
+"@markuplint/html-spec@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/html-spec@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/ml-ast": "npm:4.4.11"
-    "@markuplint/parser-utils": "npm:4.8.11"
-    parse5: "npm:8.0.0"
-    type-fest: "npm:4.41.0"
-  checksum: 10c0/68b958fe862f301a366a7c7ebcb7c0205aa7e99890d8b628c5926ec3dde6048226a63f0fe3cb56f96f5a074945df77d0daf78111c0f6dfc830001fb9a9a93cf4
+    "@markuplint/ml-spec": "npm:5.0.0-alpha.3"
+  checksum: 10c0/ca2719848d03b07bbcc472c984301a9416e6e67b2eb351f305fbcf1990c37f104f3b8107d682245af4190da6837a10f2654c781b7840b0206bc21af2ef53c0bd
   languageName: node
   linkType: hard
 
-"@markuplint/html-spec@npm:4.16.1":
-  version: 4.16.1
-  resolution: "@markuplint/html-spec@npm:4.16.1"
+"@markuplint/i18n@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/i18n@npm:5.0.0-alpha.3"
+  checksum: 10c0/05969542e0d19c47b3506ba3cf1770e594298ca95d9d568eb09cd85358df61b7bacda78b6e62af1486eed85b501a74ba951a67ea2f4d24766f53eb5f654a32a4
+  languageName: node
+  linkType: hard
+
+"@markuplint/ml-ast@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/ml-ast@npm:5.0.0-alpha.3"
+  checksum: 10c0/9fb308fc43d1431873a3626feee54a993f2254758969efbef1daf756b43e9d0e59d18a5baf3abfaf4e2b727c833fe6e590f06ef0dbd80ef1bb1a2f930927ecc2
+  languageName: node
+  linkType: hard
+
+"@markuplint/ml-config@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/ml-config@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/ml-spec": "npm:4.10.1"
-  checksum: 10c0/a5f6d834a4eee6870c36cfda1cfab4f57b0dd9774145fdd46779820b6995d63fc9dd5f1dcd7759bfdab8c3f23e4ce02ceba51b7ea1e1b6ecb916c8a213e359ce
-  languageName: node
-  linkType: hard
-
-"@markuplint/i18n@npm:4.7.0":
-  version: 4.7.0
-  resolution: "@markuplint/i18n@npm:4.7.0"
-  checksum: 10c0/6c4f5c17bed3c1466c89ba95b8f6ce78770f9b88c4af9a95206281418737374db5660689c530161ccbf335ef189c51157473d9594b4ed89c780e59160ac874de
-  languageName: node
-  linkType: hard
-
-"@markuplint/ml-ast@npm:4.4.10":
-  version: 4.4.10
-  resolution: "@markuplint/ml-ast@npm:4.4.10"
-  checksum: 10c0/bc04072020c0356c928f08182a2b2efd4c8391f12bccff6d3e87d37be3746aec5ae7a6cf8ce04a1a62c3570960fd18517187d4bd3e4516a7d9e5c92948528c6e
-  languageName: node
-  linkType: hard
-
-"@markuplint/ml-ast@npm:4.4.11":
-  version: 4.4.11
-  resolution: "@markuplint/ml-ast@npm:4.4.11"
-  checksum: 10c0/0ffc53e22a187c6db85f653e98fbd150b5a081d34e2a612c2a7085887beded9aeb12233f4f7c8ea8462487ad7241405e55b6cfe75e45707542be691866e5b91b
-  languageName: node
-  linkType: hard
-
-"@markuplint/ml-config@npm:4.8.14":
-  version: 4.8.14
-  resolution: "@markuplint/ml-config@npm:4.8.14"
-  dependencies:
-    "@markuplint/ml-ast": "npm:4.4.10"
-    "@markuplint/ml-spec": "npm:4.10.1"
-    "@markuplint/selector": "npm:4.7.7"
-    "@markuplint/shared": "npm:4.4.12"
+    "@markuplint/ml-ast": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-spec": "npm:5.0.0-alpha.3"
+    "@markuplint/selector": "npm:5.0.0-alpha.3"
+    "@markuplint/shared": "npm:5.0.0-alpha.3"
     "@types/mustache": "npm:4.2.6"
-    deepmerge: "npm:4.3.1"
     is-plain-object: "npm:5.0.0"
     mustache: "npm:4.2.0"
-    type-fest: "npm:4.41.0"
-  checksum: 10c0/98af7684b6952ce022eff1a2fde613e3fbdf00e6573aa040a72f70d0360001968a0aabaef9cf8fc25b8b727e7a7d9fd6e5f3ee8742921dd62dc8422f7ffb2fea
+    type-fest: "npm:5.4.4"
+  checksum: 10c0/16f34f9716807104fe0caeac4192cf4420d52129c0a610d23bd0ec9a6cc65c6e1896a196847e8c0742d8ae2c79272c58b69e6174adf6ae71a6a28fc56223f20b
   languageName: node
   linkType: hard
 
-"@markuplint/ml-core@npm:4.13.2":
-  version: 4.13.2
-  resolution: "@markuplint/ml-core@npm:4.13.2"
+"@markuplint/ml-core@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/ml-core@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/config-presets": "npm:4.5.13"
-    "@markuplint/html-parser": "npm:4.6.22"
-    "@markuplint/html-spec": "npm:4.16.1"
-    "@markuplint/i18n": "npm:4.7.0"
-    "@markuplint/ml-ast": "npm:4.4.10"
-    "@markuplint/ml-config": "npm:4.8.14"
-    "@markuplint/ml-spec": "npm:4.10.1"
-    "@markuplint/parser-utils": "npm:4.8.10"
-    "@markuplint/selector": "npm:4.7.7"
-    "@markuplint/shared": "npm:4.4.12"
+    "@markuplint/config-presets": "npm:5.0.0-alpha.3"
+    "@markuplint/html-parser": "npm:5.0.0-alpha.3"
+    "@markuplint/html-spec": "npm:5.0.0-alpha.3"
+    "@markuplint/i18n": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-ast": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-config": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-spec": "npm:5.0.0-alpha.3"
+    "@markuplint/parser-utils": "npm:5.0.0-alpha.3"
+    "@markuplint/selector": "npm:5.0.0-alpha.3"
+    "@markuplint/shared": "npm:5.0.0-alpha.3"
     "@types/debug": "npm:4.1.12"
     debug: "npm:4.4.3"
     is-plain-object: "npm:5.0.0"
-    type-fest: "npm:4.41.0"
-  checksum: 10c0/b787ec7e02d61ddc737e00f20670c9621d130ef23c0bea039071b929ac36b493642d09dac97bb258d9f5ac2b755f1ed397fbd223df4cfde21e032806dd1be340
+    type-fest: "npm:5.4.4"
+  checksum: 10c0/883fca0f029b3f7832ed1616c61296a252bb8c7f55ea88aef4e23c8d32ffe68ad39c2ced08f737fb775cc9f3a035508a9edb14efe0fc2ca6c9bf397c9332a590
   languageName: node
   linkType: hard
 
-"@markuplint/ml-spec@npm:4.10.1":
-  version: 4.10.1
-  resolution: "@markuplint/ml-spec@npm:4.10.1"
+"@markuplint/ml-spec@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/ml-spec@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/ml-ast": "npm:4.4.10"
-    "@markuplint/types": "npm:4.8.1"
-    dom-accessibility-api: "npm:0.7.0"
+    "@markuplint/ml-ast": "npm:5.0.0-alpha.3"
+    "@markuplint/types": "npm:5.0.0-alpha.3"
     is-plain-object: "npm:5.0.0"
-    type-fest: "npm:4.41.0"
-  checksum: 10c0/3bcc8dc7d37f2b31ecdd47c3fdf4950d4dff2f6a11d3c7950e72ccf8c4841a08c53f12e8d26641a4815b3610b0b66bb35f5f42477688046a74a6273f7b591410
+    type-fest: "npm:5.4.4"
+  checksum: 10c0/58cfd9e98178f7306509cc67669b82403ec7dd3d12df141d516847a00e1441a778a824e4db53e8703ce38a2369a35beda5afd9295094fa0462c715ae5a1baab0
   languageName: node
   linkType: hard
 
-"@markuplint/ml-spec@npm:4.10.2":
-  version: 4.10.2
-  resolution: "@markuplint/ml-spec@npm:4.10.2"
+"@markuplint/parser-utils@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/parser-utils@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/ml-ast": "npm:4.4.11"
-    "@markuplint/types": "npm:4.8.2"
-    dom-accessibility-api: "npm:0.7.1"
-    is-plain-object: "npm:5.0.0"
-    type-fest: "npm:4.41.0"
-  checksum: 10c0/911de5ef10adc72bdffa3c02fdd8756b8bd4eb0d632daefd33d68eb03eeb78cf3542dcc076b7a6bf334f78a884ccdf6caf58bf0c0dfb8022ed4054b79679036d
-  languageName: node
-  linkType: hard
-
-"@markuplint/parser-utils@npm:4.8.10":
-  version: 4.8.10
-  resolution: "@markuplint/parser-utils@npm:4.8.10"
-  dependencies:
-    "@markuplint/ml-ast": "npm:4.4.10"
-    "@markuplint/ml-spec": "npm:4.10.1"
-    "@markuplint/types": "npm:4.8.1"
-    "@types/uuid": "npm:10.0.0"
+    "@markuplint/ml-ast": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-spec": "npm:5.0.0-alpha.3"
+    "@markuplint/shared": "npm:5.0.0-alpha.3"
+    "@markuplint/types": "npm:5.0.0-alpha.3"
     debug: "npm:4.4.3"
-    espree: "npm:10.4.0"
-    type-fest: "npm:4.41.0"
-    uuid: "npm:13.0.0"
-  checksum: 10c0/c12c9197c260ff020ad0fa2ea898d5148b60a71d84301f78f6e9d5255a9cfe46417961abf6c340d4fa62d70f81ebf517b28acbf16e60e5b5b4e98c4e109b9422
+    espree: "npm:11.1.1"
+    type-fest: "npm:5.4.4"
+  checksum: 10c0/0633e5a0c1eaf216ddc6ed9060b1e81897cc5aca86ff0156b3a74d6b421de3d20bb0899541653e6566a66cbabb01511079ee4ec622083aeca0113e68b29b02cb
   languageName: node
   linkType: hard
 
-"@markuplint/parser-utils@npm:4.8.11":
-  version: 4.8.11
-  resolution: "@markuplint/parser-utils@npm:4.8.11"
+"@markuplint/pug-parser@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/pug-parser@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/ml-ast": "npm:4.4.11"
-    "@markuplint/ml-spec": "npm:4.10.2"
-    "@markuplint/types": "npm:4.8.2"
-    "@types/uuid": "npm:11.0.0"
-    debug: "npm:4.4.3"
-    espree: "npm:11.1.0"
-    type-fest: "npm:4.41.0"
-    uuid: "npm:13.0.0"
-  checksum: 10c0/75c9f70eb79cfeb4ccd4c5fed4afe5ff5632c5367538f58a95dc48744f3e6116cbe4a99f7ef64a484a38b4579ab5c3143e5716c0cfb0b5060f8bd284205d02d6
-  languageName: node
-  linkType: hard
-
-"@markuplint/pug-parser@npm:4.6.23":
-  version: 4.6.23
-  resolution: "@markuplint/pug-parser@npm:4.6.23"
-  dependencies:
-    "@markuplint/html-parser": "npm:4.6.23"
-    "@markuplint/ml-ast": "npm:4.4.11"
-    "@markuplint/parser-utils": "npm:4.8.11"
+    "@markuplint/html-parser": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-ast": "npm:5.0.0-alpha.3"
+    "@markuplint/parser-utils": "npm:5.0.0-alpha.3"
     pug-lexer: "npm:5.0.1"
     pug-parser: "npm:6.0.0"
-  checksum: 10c0/f5725d17993a1a7af76f96262eecdce23aa8b6e05e4a50335519b4e6b9cf2281bfe5a5cf56521ac9083a471e73b7f53200fa2eab9725d843eede883589c53a59
+  checksum: 10c0/f83a8b4cd17c91edf7241980af696047874ba9b7801492e8dc963b56810315a8d16883541a79c54ba70c9d33cab8e22f4ae9a07cceee8744ac789d707a6b4603
   languageName: node
   linkType: hard
 
-"@markuplint/rules@npm:4.11.2":
-  version: 4.11.2
-  resolution: "@markuplint/rules@npm:4.11.2"
+"@markuplint/rules@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/rules@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/html-spec": "npm:4.16.1"
-    "@markuplint/ml-core": "npm:4.13.2"
-    "@markuplint/ml-spec": "npm:4.10.1"
-    "@markuplint/selector": "npm:4.7.7"
-    "@markuplint/shared": "npm:4.4.12"
-    "@markuplint/types": "npm:4.8.1"
+    "@markuplint/html-spec": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-core": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-spec": "npm:5.0.0-alpha.3"
+    "@markuplint/selector": "npm:5.0.0-alpha.3"
+    "@markuplint/shared": "npm:5.0.0-alpha.3"
+    "@markuplint/types": "npm:5.0.0-alpha.3"
+    "@mdn/browser-compat-data": "npm:^7.3.2"
     "@types/debug": "npm:4.1.12"
-    "@ungap/structured-clone": "npm:1.3.0"
     ansi-colors: "npm:4.1.3"
-    chrono-node: "npm:2.8.4"
+    browserslist: "npm:^4.28.1"
+    chrono-node: "npm:2.9.0"
     debug: "npm:4.4.3"
-    type-fest: "npm:4.41.0"
-  checksum: 10c0/a5ac020e74f09b1b1342ec4accc2fdc33c191db60a14a1a35e443aca2bf3bc8636f7b6e47c8889478188ce1aaff6e73acf2afa383247298d77e42a1756043dd2
+    image-size: "npm:^2.0.2"
+    type-fest: "npm:5.4.4"
+  checksum: 10c0/fd0c24cff5d7b0731ec29be3ccf09bd4c10929462ff24755750189bd73b408f01864fa014e25315d898f768435d7e81fc6bd1ef2341ead6c66f1279277db7950
   languageName: node
   linkType: hard
 
-"@markuplint/selector@npm:4.7.7":
-  version: 4.7.7
-  resolution: "@markuplint/selector@npm:4.7.7"
+"@markuplint/selector@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/selector@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/ml-spec": "npm:4.10.1"
+    "@markuplint/ml-spec": "npm:5.0.0-alpha.3"
     "@types/debug": "npm:4.1.12"
     debug: "npm:4.4.3"
-    postcss-selector-parser: "npm:7.1.0"
-    type-fest: "npm:4.41.0"
-  checksum: 10c0/8192e22711aa3f102d4f1d161036abfe6b63974155f99114a57d9284623ed327ffe07be4b5772fff6f49b8660525cc3dc5ba99f5394f96e768b241b0dc9ae0fd
+    postcss-selector-parser: "npm:7.1.1"
+    type-fest: "npm:5.4.4"
+  checksum: 10c0/cafb3451410bbb249fdc7775148d7ca3079c7c7748ce8a2b3fb36981f0f1dc6ddf460084c55887e8405edc2c706234060be6b5e351faff407936d70f10278f5e
   languageName: node
   linkType: hard
 
-"@markuplint/shared@npm:4.4.12":
-  version: 4.4.12
-  resolution: "@markuplint/shared@npm:4.4.12"
+"@markuplint/shared@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/shared@npm:5.0.0-alpha.3"
   dependencies:
     html-entities: "npm:2.6.0"
-  checksum: 10c0/a75f378be4dcb1cb1ba9c99b9d5fe48e3a33da0e58c6d793d566c198b1d31027c88f7049cba2231f2ca214522c4f2c0bf54ff65444b6747dcc69cb654852b431
+  checksum: 10c0/dfd8f5ac0fb871d1d6c30a6c43b16bad464f8e2ef4a1f5669118a6a90164328a10680543c99d566954b7586719490045ac31766b29645308cbbce7b1bb79bbe1
   languageName: node
   linkType: hard
 
-"@markuplint/shared@npm:4.4.13":
-  version: 4.4.13
-  resolution: "@markuplint/shared@npm:4.4.13"
+"@markuplint/types@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "@markuplint/types@npm:5.0.0-alpha.3"
   dependencies:
-    html-entities: "npm:2.6.0"
-  checksum: 10c0/c5bc51b5745a84af98e0f28309fbc953d45881e2af9ae83c521da4b8ec96722a0ff84533073c58fd7ebe74726397e1ca030b4853b9e9662d77c8e5739a6c0a90
-  languageName: node
-  linkType: hard
-
-"@markuplint/types@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@markuplint/types@npm:4.8.1"
-  dependencies:
-    "@markuplint/shared": "npm:4.4.12"
+    "@markuplint/shared": "npm:5.0.0-alpha.3"
     "@types/css-tree": "npm:2.3.11"
     "@types/debug": "npm:4.1.12"
-    "@types/whatwg-mimetype": "npm:3.0.2"
     bcp-47: "npm:2.1.0"
     css-tree: "npm:3.1.0"
     debug: "npm:4.4.3"
     leven: "npm:4.1.0"
-    type-fest: "npm:4.41.0"
-    whatwg-mimetype: "npm:4.0.0"
-  checksum: 10c0/a5c22a2612baec29c22ad30298a74c7af1d0449a9ec9349906d3381cb7ff31dc57c9bbae6ce7084c1969b373ffaf539b54c195032525e0e137b1577bd2731c86
+    type-fest: "npm:5.4.4"
+    whatwg-mimetype: "npm:5.0.0"
+  checksum: 10c0/4adbde676f22331dbce4e629c3d41e32f5e60d4549041daa0164ad84f77e0fc8d026c7360dc7e06151f01f4a29e5ae465ef255f7c3d4a8a323fbeb0ce9caf506
   languageName: node
   linkType: hard
 
-"@markuplint/types@npm:4.8.2":
-  version: 4.8.2
-  resolution: "@markuplint/types@npm:4.8.2"
-  dependencies:
-    "@markuplint/shared": "npm:4.4.13"
-    "@types/css-tree": "npm:2.3.11"
-    "@types/debug": "npm:4.1.12"
-    "@types/whatwg-mimetype": "npm:3.0.2"
-    bcp-47: "npm:2.1.0"
-    css-tree: "npm:3.1.0"
-    debug: "npm:4.4.3"
-    leven: "npm:4.1.0"
-    type-fest: "npm:4.41.0"
-    whatwg-mimetype: "npm:4.0.0"
-  checksum: 10c0/2f6db1ce3df629f5d8de0140df151cd4c0ffac7fe0599167178372faf11c2216b46774992500987ad3acd8c7a148e0c1fb4041cba1f8580a04877c6d9df17142
+"@mdn/browser-compat-data@npm:^7.3.2":
+  version: 7.3.4
+  resolution: "@mdn/browser-compat-data@npm:7.3.4"
+  checksum: 10c0/54ca20fe421b7ecffc92668982feb30ad814783a04535256b1595b974699677fb00dbae90ce71bebfbfba00015a4bd04c24672b173ef64378578fc21e4f96ad9
   languageName: node
   linkType: hard
 
@@ -3744,29 +3674,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:10.0.0":
-  version: 10.0.0
-  resolution: "@types/uuid@npm:10.0.0"
-  checksum: 10c0/9a1404bf287164481cb9b97f6bb638f78f955be57c40c6513b7655160beb29df6f84c915aaf4089a1559c216557dc4d2f79b48d978742d3ae10b937420ddac60
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:11.0.0":
-  version: 11.0.0
-  resolution: "@types/uuid@npm:11.0.0"
-  dependencies:
-    uuid: "npm:*"
-  checksum: 10c0/6ebf1448d8fdc78d348a8a84389b74083f2f58bed75a5a6cf3be8419d33dcf757735c8b2de746b066ff8ef07f4384d02549774dc84195ffa46b24745471e9d8e
-  languageName: node
-  linkType: hard
-
-"@types/whatwg-mimetype@npm:3.0.2":
-  version: 3.0.2
-  resolution: "@types/whatwg-mimetype@npm:3.0.2"
-  checksum: 10c0/dad39d1e4abe760a0a963c84bbdbd26b1df0eb68aff83bdf6ecbb50ad781ead777f6906d19a87007790b750f7500a12e5624d31fc6a1529d14bd19b5c3a316d1
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/eslint-plugin@npm:8.56.1":
   version: 8.56.1
   resolution: "@typescript-eslint/eslint-plugin@npm:8.56.1"
@@ -3913,13 +3820,6 @@ __metadata:
     "@typescript-eslint/types": "npm:8.56.1"
     eslint-visitor-keys: "npm:^5.0.0"
   checksum: 10c0/86d97905dec1af964cc177c185933d040449acf6006096497f2e0093c6a53eb92b3ac1db9eb40a5a2e8d91160f558c9734331a9280797f09f284c38978b22190
-  languageName: node
-  linkType: hard
-
-"@ungap/structured-clone@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@ungap/structured-clone@npm:1.3.0"
-  checksum: 10c0/0fc3097c2540ada1fc340ee56d58d96b5b536a2a0dab6e3ec17d4bfc8c4c86db345f61a375a8185f9da96f01c69678f836a2b57eeaa9e4b8eeafd26428e57b0a
   languageName: node
   linkType: hard
 
@@ -4235,6 +4135,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 10c0/dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.16.0":
+  version: 8.16.0
+  resolution: "acorn@npm:8.16.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/c9c52697227661b68d0debaf972222d4f622aa06b185824164e153438afa7b08273432ca43ea792cadb24dada1d46f6f6bb1ef8de9956979288cc1b96bf9914e
   languageName: node
   linkType: hard
 
@@ -4744,6 +4653,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.28.1":
+  version: 4.28.1
+  resolution: "browserslist@npm:4.28.1"
+  dependencies:
+    baseline-browser-mapping: "npm:^2.9.0"
+    caniuse-lite: "npm:^1.0.30001759"
+    electron-to-chromium: "npm:^1.5.263"
+    node-releases: "npm:^2.0.27"
+    update-browserslist-db: "npm:^1.2.0"
+  bin:
+    browserslist: cli.js
+  checksum: 10c0/545a5fa9d7234e3777a7177ec1e9134bb2ba60a69e6b95683f6982b1473aad347c77c1264ccf2ac5dea609a9731fbfbda6b85782bdca70f80f86e28a402504bd
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -4919,6 +4843,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"caniuse-lite@npm:^1.0.30001759":
+  version: 1.0.30001774
+  resolution: "caniuse-lite@npm:1.0.30001774"
+  checksum: 10c0/cc6a340a5421b9a67d8fa80889065ee27b2839ad62993571dded5296e18f02bbf685ce7094e93fe908cddc9fefdfad35d6c010b724cc3d22a6479b0d0b679f8c
+  languageName: node
+  linkType: hard
+
 "ccount@npm:^1.0.0, ccount@npm:^1.0.3":
   version: 1.1.0
   resolution: "ccount@npm:1.1.0"
@@ -5045,12 +4976,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:4.0.3":
-  version: 4.0.3
-  resolution: "chokidar@npm:4.0.3"
+"chokidar@npm:5.0.0":
+  version: 5.0.0
+  resolution: "chokidar@npm:5.0.0"
   dependencies:
-    readdirp: "npm:^4.0.1"
-  checksum: 10c0/a58b9df05bb452f7d105d9e7229ac82fa873741c0c40ddcc7bb82f8a909fbe3f7814c9ebe9bc9a2bef9b737c0ec6e2d699d179048ef06ad3ec46315df0ebe6ad
+    readdirp: "npm:^5.0.0"
+  checksum: 10c0/42fc907cb2a7ff5c9e220f84dae75380a77997f851c2a5e7865a2cf9ae45dd407a23557208cdcdbf3ac8c93341135a1748e4c48c31855f3bfa095e5159b6bdec
   languageName: node
   linkType: hard
 
@@ -5061,12 +4992,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chrono-node@npm:2.8.4":
-  version: 2.8.4
-  resolution: "chrono-node@npm:2.8.4"
-  dependencies:
-    dayjs: "npm:^1.10.0"
-  checksum: 10c0/675acdd2945a093b17511a2c112751f7f858b526ded90bc82d922b37173af9fbceaec0a00fbdf61a099bd4f26d12497bc6e5e2740c66eb04ebcfcef63806011c
+"chrono-node@npm:2.9.0":
+  version: 2.9.0
+  resolution: "chrono-node@npm:2.9.0"
+  checksum: 10c0/940290d2063763e44a64d5d17c54646ca335cdd538c56ad263a2133a53bf2aad1cf5b3d34648bccd980136da0bcd0cdbd5139580b17b41510725684efafc1332
   languageName: node
   linkType: hard
 
@@ -5926,13 +5855,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.10.0":
-  version: 1.11.13
-  resolution: "dayjs@npm:1.11.13"
-  checksum: 10c0/a3caf6ac8363c7dade9d1ee797848ddcf25c1ace68d9fe8678ecf8ba0675825430de5d793672ec87b24a69bf04a1544b176547b2539982275d5542a7955f35b7
-  languageName: node
-  linkType: hard
-
 "debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0, debug@npm:^4.4.1":
   version: 4.4.1
   resolution: "debug@npm:4.4.1"
@@ -5997,13 +5919,6 @@ __metadata:
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
   checksum: 10c0/7f0ee496e0dff14a573dc6127f14c95061b448b87b995fc96c017ce0a1e66af1675e73f1d6064407975bc4ea6ab679497a29fff7b5b9c4e99cb10797c1ad0b4c
-  languageName: node
-  linkType: hard
-
-"deepmerge@npm:4.3.1":
-  version: 4.3.1
-  resolution: "deepmerge@npm:4.3.1"
-  checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
   languageName: node
   linkType: hard
 
@@ -6110,20 +6025,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-accessibility-api@npm:0.7.0":
-  version: 0.7.0
-  resolution: "dom-accessibility-api@npm:0.7.0"
-  checksum: 10c0/51d3fe283b0b4882442ba7cd7c76d27aa96b57e1854f0373be62c0abfaa95e89f4c1a1b883712814dc52b0a0853147f6de681fae20467a29d3a485df9b7329d8
-  languageName: node
-  linkType: hard
-
-"dom-accessibility-api@npm:0.7.1":
-  version: 0.7.1
-  resolution: "dom-accessibility-api@npm:0.7.1"
-  checksum: 10c0/1667710482e373913d610828c3eba062165bd747f7d7b5309d70a8ef02ebe14d3f26ec1b2a8edb6d9c9c045bd755426fdc87941e88d70c0e9907fd1ba762b277
-  languageName: node
-  linkType: hard
-
 "dot-prop@npm:^5.1.0":
   version: 5.3.0
   resolution: "dot-prop@npm:5.3.0"
@@ -6226,6 +6127,13 @@ __metadata:
   version: 1.5.259
   resolution: "electron-to-chromium@npm:1.5.259"
   checksum: 10c0/a6600ff20d513e1acce29cd04af5fcb338295ebe5a13fa9802009464d9c269a4a092218c8ea8c9b85017a1efd75606fe0cdf5f36216979f7c8462af7df2f530d
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.5.263":
+  version: 1.5.302
+  resolution: "electron-to-chromium@npm:1.5.302"
+  checksum: 10c0/014413f2b4ec3a0e043c68f6c07a760d230b14e36b8549c5b124f386a6318d9641e69be2aa0df1877395dd99922745c1722c8ecb3d72205f0f3b3b3dc44c8442
   languageName: node
   linkType: hard
 
@@ -6665,6 +6573,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-visitor-keys@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eslint-visitor-keys@npm:5.0.1"
+  checksum: 10c0/16190bdf2cbae40a1109384c94450c526a79b0b9c3cb21e544256ed85ac48a4b84db66b74a6561d20fe6ab77447f150d711c2ad5ad74df4fcc133736bce99678
+  languageName: node
+  linkType: hard
+
 "eslint@npm:9.39.3":
   version: 9.39.3
   resolution: "eslint@npm:9.39.3"
@@ -6714,7 +6629,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:10.4.0, espree@npm:^10.0.1, espree@npm:^10.4.0":
+"espree@npm:11.1.1":
+  version: 11.1.1
+  resolution: "espree@npm:11.1.1"
+  dependencies:
+    acorn: "npm:^8.16.0"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^5.0.1"
+  checksum: 10c0/2feae74efdfb037b9e9fcb30506799845cf20900de5e441ed03e5c51aaa249f85ea5818ff177682acc0c9bfb4ac97e1965c238ee44ac7c305aab8747177bab69
+  languageName: node
+  linkType: hard
+
+"espree@npm:^10.0.1, espree@npm:^10.4.0":
   version: 10.4.0
   resolution: "espree@npm:10.4.0"
   dependencies:
@@ -6725,7 +6651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:11.1.0, espree@npm:^11.1.0":
+"espree@npm:^11.1.0":
   version: 11.1.0
   resolution: "espree@npm:11.1.0"
   dependencies:
@@ -7653,19 +7579,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:11.0.3, glob@npm:^11.0.3":
-  version: 11.0.3
-  resolution: "glob@npm:11.0.3"
+"glob@npm:13.0.6, glob@npm:^13.0.3":
+  version: 13.0.6
+  resolution: "glob@npm:13.0.6"
   dependencies:
-    foreground-child: "npm:^3.3.1"
-    jackspeak: "npm:^4.1.1"
-    minimatch: "npm:^10.0.3"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^2.0.0"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10c0/7d24457549ec2903920dfa3d8e76850e7c02aa709122f0164b240c712f5455c0b457e6f2a1eee39344c6148e39895be8094ae8cfef7ccc3296ed30bce250c661
+    minimatch: "npm:^10.2.2"
+    minipass: "npm:^7.1.3"
+    path-scurry: "npm:^2.0.2"
+  checksum: 10c0/269c236f11a9b50357fe7a8c6aadac667e01deb5242b19c84975628f05f4438d8ee1354bb62c5d6c10f37fd59911b54d7799730633a2786660d8c69f1d18120a
   languageName: node
   linkType: hard
 
@@ -7699,6 +7620,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^11.0.3":
+  version: 11.0.3
+  resolution: "glob@npm:11.0.3"
+  dependencies:
+    foreground-child: "npm:^3.3.1"
+    jackspeak: "npm:^4.1.1"
+    minimatch: "npm:^10.0.3"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/7d24457549ec2903920dfa3d8e76850e7c02aa709122f0164b240c712f5455c0b457e6f2a1eee39344c6148e39895be8094ae8cfef7ccc3296ed30bce250c661
+  languageName: node
+  linkType: hard
+
 "glob@npm:^11.1.0":
   version: 11.1.0
   resolution: "glob@npm:11.1.0"
@@ -7728,17 +7665,6 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10c0/923fbb7e30913496dc1c30191edb7ebb610a26edac81710a5f697c718b08694bce7fb0245baceba5383472778a8431ff7c36571703507cc6563602d3c139c993
-  languageName: node
-  linkType: hard
-
-"glob@npm:^13.0.3":
-  version: 13.0.6
-  resolution: "glob@npm:13.0.6"
-  dependencies:
-    minimatch: "npm:^10.2.2"
-    minipass: "npm:^7.1.3"
-    path-scurry: "npm:^2.0.2"
-  checksum: 10c0/269c236f11a9b50357fe7a8c6aadac667e01deb5242b19c84975628f05f4438d8ee1354bb62c5d6c10f37fd59911b54d7799730633a2786660d8c69f1d18120a
   languageName: node
   linkType: hard
 
@@ -7943,10 +7869,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-yarn@npm:3.0.0":
-  version: 3.0.0
-  resolution: "has-yarn@npm:3.0.0"
-  checksum: 10c0/38c76618cb764e4a98ea114a3938e0bed6ceafb6bacab2ffb32e7c7d1e18b5e09cd03387d507ee87072388e1f20b1f80947fee62c41fc450edfbbdc02a665787
+"has-yarn@npm:4.0.0":
+  version: 4.0.0
+  resolution: "has-yarn@npm:4.0.0"
+  dependencies:
+    find-up-simple: "npm:^1.0.1"
+  checksum: 10c0/c7012d973db4b2f7d50e126f3c8294eb8c6d2c8dc5b1474a34fdeb17bbda6d8ceef5808ffc8aecf8c25405c5487039828ac6ddb532ee26505f4023eb3c9e6ddf
   languageName: node
   linkType: hard
 
@@ -8266,6 +8194,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"image-size@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "image-size@npm:2.0.2"
+  bin:
+    image-size: bin/image-size.js
+  checksum: 10c0/f09dd0f7cf8511cd20e4f756bdb5a7cb6d2240de3323f41bde266bed8373392a293892bf12e907e2995f52833fd88dd27cf6b1a52ab93968afc716cb78cd7b79
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0, import-fresh@npm:^3.3.1":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
@@ -8444,13 +8381,6 @@ __metadata:
     strip-ansi: "npm:^5.1.0"
     through: "npm:^2.3.6"
   checksum: 10c0/a5aa53a8f88405cf1cff63111493f87a5b3b5deb5ea4a0dbcd73ccc06a51a6bba0c3f1a0747f8880e9e3ec2437c69f90417be16368abf636b1d29eebe35db0ac
-  languageName: node
-  linkType: hard
-
-"invert-kv@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "invert-kv@npm:3.0.1"
-  checksum: 10c0/a3d90951a635e35dea9c9a5fd749e981e9c54e8a362ad80b2253dad03b9257314b7c4e4d250d61bcd79698ccd5f4c6b0c750cd991bb5ce16352bf830e77ea64b
   languageName: node
   linkType: hard
 
@@ -9187,15 +9117,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lcid@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "lcid@npm:3.1.1"
-  dependencies:
-    invert-kv: "npm:^3.0.0"
-  checksum: 10c0/43a39c39d92d756b9671691bb36ac2667c44c4a7e30f55403dc9c98ca4e7bba8c2b35599e8d7967163d65c1697e0d136596e9a9b9bccbd2292caf915c77416a4
-  languageName: node
-  linkType: hard
-
 "lerna@npm:9.0.4":
   version: 9.0.4
   resolution: "lerna@npm:9.0.4"
@@ -9715,32 +9636,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markuplint@npm:4.14.0":
-  version: 4.14.0
-  resolution: "markuplint@npm:4.14.0"
+"markuplint@npm:5.0.0-alpha.3":
+  version: 5.0.0-alpha.3
+  resolution: "markuplint@npm:5.0.0-alpha.3"
   dependencies:
-    "@markuplint/cli-utils": "npm:4.4.13"
-    "@markuplint/file-resolver": "npm:4.9.17"
-    "@markuplint/html-parser": "npm:4.6.22"
-    "@markuplint/html-spec": "npm:4.16.1"
-    "@markuplint/i18n": "npm:4.7.0"
-    "@markuplint/ml-ast": "npm:4.4.10"
-    "@markuplint/ml-config": "npm:4.8.14"
-    "@markuplint/ml-core": "npm:4.13.2"
-    "@markuplint/ml-spec": "npm:4.10.1"
-    "@markuplint/rules": "npm:4.11.2"
-    "@markuplint/shared": "npm:4.4.12"
+    "@markuplint/cli-utils": "npm:5.0.0-alpha.3"
+    "@markuplint/file-resolver": "npm:5.0.0-alpha.3"
+    "@markuplint/html-parser": "npm:5.0.0-alpha.3"
+    "@markuplint/html-spec": "npm:5.0.0-alpha.3"
+    "@markuplint/i18n": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-ast": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-config": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-core": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-spec": "npm:5.0.0-alpha.3"
+    "@markuplint/rules": "npm:5.0.0-alpha.3"
+    "@markuplint/shared": "npm:5.0.0-alpha.3"
     "@types/debug": "npm:4.1.12"
-    chokidar: "npm:4.0.3"
+    chokidar: "npm:5.0.0"
     debug: "npm:4.4.3"
-    meow: "npm:13.2.0"
-    os-locale: "npm:6.0.2"
+    meow: "npm:14.1.0"
+    os-locale: "npm:8.0.0"
     strict-event-emitter: "npm:0.5.1"
     strip-ansi: "npm:7.1.2"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
   bin:
-    markuplint: ./bin/markuplint.mjs
-  checksum: 10c0/cf78ca7fc0a787d4c3c29741c9f9a67261d8ba90d14e9de8c1d72e530d808ab3beaf68dae2e46d66aa92030622b2f18c6313145cbfa1e14d75ae47c636efcb7d
+    markuplint: bin/markuplint.mjs
+  checksum: 10c0/40711c030d9a34222f7e426d6ceb4cf754fdb63905c8ac91dde11c5f2b6d92ad061eab2ddf708b23f926f1795865b320d03eb6d0ab3b30c779ec5fdf99d2b69f
   languageName: node
   linkType: hard
 
@@ -9922,10 +9843,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"meow@npm:13.2.0, meow@npm:^13.0.0":
-  version: 13.2.0
-  resolution: "meow@npm:13.2.0"
-  checksum: 10c0/d5b339ae314715bcd0b619dd2f8a266891928e21526b4800d49b4fba1cc3fff7e2c1ff5edd3344149fac841bc2306157f858e8c4d5eaee4d52ce52ad925664ce
+"meow@npm:14.1.0":
+  version: 14.1.0
+  resolution: "meow@npm:14.1.0"
+  checksum: 10c0/f0ca4bb4fd08e4b9470fcbb7332deb61d72d40d4bda18ffb87c1a98e5014c0b44749ae9f0cab18fa532e26d61cef5d453831f9ae23ac09fa8ea0e0469be73ebc
   languageName: node
   linkType: hard
 
@@ -9933,6 +9854,13 @@ __metadata:
   version: 12.1.1
   resolution: "meow@npm:12.1.1"
   checksum: 10c0/a125ca99a32e2306e2f4cbe651a0d27f6eb67918d43a075f6e80b35e9bf372ebf0fc3a9fbc201cbbc9516444b6265fb3c9f80c5b7ebd32f548aa93eb7c28e088
+  languageName: node
+  linkType: hard
+
+"meow@npm:^13.0.0":
+  version: 13.2.0
+  resolution: "meow@npm:13.2.0"
+  checksum: 10c0/d5b339ae314715bcd0b619dd2f8a266891928e21526b4800d49b4fba1cc3fff7e2c1ff5edd3344149fac841bc2306157f858e8c4d5eaee4d52ce52ad925664ce
   languageName: node
   linkType: hard
 
@@ -10145,12 +10073,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:10.0.3, minimatch@npm:^10.0.3, minimatch@npm:^9.0.3 || ^10.0.1":
-  version: 10.0.3
-  resolution: "minimatch@npm:10.0.3"
+"minimatch@npm:10.2.4":
+  version: 10.2.4
+  resolution: "minimatch@npm:10.2.4"
   dependencies:
-    "@isaacs/brace-expansion": "npm:^5.0.0"
-  checksum: 10c0/e43e4a905c5d70ac4cec8530ceaeccb9c544b1ba8ac45238e2a78121a01c17ff0c373346472d221872563204eabe929ad02669bb575cb1f0cc30facab369f70f
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
   languageName: node
   linkType: hard
 
@@ -10169,6 +10097,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^2.0.1"
   checksum: 10c0/85f407dcd38ac3e180f425e86553911d101455ca3ad5544d6a7cec16286657e4f8a9aa6695803025c55e31e35a91a2252b5dc8e7d527211278b8b65b4dbd5eac
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.0.3, minimatch@npm:^9.0.3 || ^10.0.1":
+  version: 10.0.3
+  resolution: "minimatch@npm:10.0.3"
+  dependencies:
+    "@isaacs/brace-expansion": "npm:^5.0.0"
+  checksum: 10c0/e43e4a905c5d70ac4cec8530ceaeccb9c544b1ba8ac45238e2a78121a01c17ff0c373346472d221872563204eabe929ad02669bb575cb1f0cc30facab369f70f
   languageName: node
   linkType: hard
 
@@ -11038,12 +10975,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-locale@npm:6.0.2":
-  version: 6.0.2
-  resolution: "os-locale@npm:6.0.2"
-  dependencies:
-    lcid: "npm:^3.1.1"
-  checksum: 10c0/15778a074367ff91ab7a3701f374fca8897cdea39e5c542c4df58a6ada0b811f0e98eb0e3a5401ca7dcf29bd20f37c9786864dbe051b363c56ecd2f481f90254
+"os-locale@npm:8.0.0":
+  version: 8.0.0
+  resolution: "os-locale@npm:8.0.0"
+  checksum: 10c0/5e7bea7afcbfb70c8b36424aadf85f7f170aabc7b50735f73ebe45046082a346f354bc9b79718bd304c0d7f2439825258617b67c7d9440cff7e88131b5426329
   languageName: node
   linkType: hard
 
@@ -11679,16 +11614,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:7.1.0, postcss-selector-parser@npm:^7.0.0":
-  version: 7.1.0
-  resolution: "postcss-selector-parser@npm:7.1.0"
-  dependencies:
-    cssesc: "npm:^3.0.0"
-    util-deprecate: "npm:^1.0.2"
-  checksum: 10c0/0fef257cfd1c0fe93c18a3f8a6e739b4438b527054fd77e9a62730a89b2d0ded1b59314a7e4aaa55bc256204f40830fecd2eb50f20f8cb7ab3a10b52aa06c8aa
-  languageName: node
-  linkType: hard
-
 "postcss-selector-parser@npm:7.1.1, postcss-selector-parser@npm:^7.1.1":
   version: 7.1.1
   resolution: "postcss-selector-parser@npm:7.1.1"
@@ -11696,6 +11621,16 @@ __metadata:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
   checksum: 10c0/02d3b1589ddcddceed4b583b098b95a7266dacd5135f041e5d913ebb48e874fd333a36e564cc9a2ec426a464cb18db11cb192ac76247aced5eba8c951bf59507
+  languageName: node
+  linkType: hard
+
+"postcss-selector-parser@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "postcss-selector-parser@npm:7.1.0"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 10c0/0fef257cfd1c0fe93c18a3f8a6e739b4438b527054fd77e9a62730a89b2d0ded1b59314a7e4aaa55bc256204f40830fecd2eb50f20f8cb7ab3a10b52aa06c8aa
   languageName: node
   linkType: hard
 
@@ -12197,10 +12132,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readdirp@npm:^4.0.1":
-  version: 4.1.2
-  resolution: "readdirp@npm:4.1.2"
-  checksum: 10c0/60a14f7619dec48c9c850255cd523e2717001b0e179dc7037cfa0895da7b9e9ab07532d324bfb118d73a710887d1e35f79c495fa91582784493e085d18c72c62
+"readdirp@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "readdirp@npm:5.0.0"
+  checksum: 10c0/faf1ec57cff2020f473128da3f8d2a57813cc3a08a36c38cae1c9af32c1579906cc50ba75578043b35bade77e945c098233665797cf9730ba3613a62d6e79219
   languageName: node
   linkType: hard
 
@@ -13571,6 +13506,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10c0/91d25c9ffb86a91f20522cefb2cbec9b64caa1febe27ad0df52f08993ff60888022d771e868e6416cf2e72dab68449d2139e8709ba009b74c6c7ecd4000048d1
+  languageName: node
+  linkType: hard
+
 "tar-stream@npm:~2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
@@ -14225,10 +14167,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:4.41.0, type-fest@npm:^4.39.1, type-fest@npm:^4.6.0":
-  version: 4.41.0
-  resolution: "type-fest@npm:4.41.0"
-  checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
+"type-fest@npm:5.4.4":
+  version: 5.4.4
+  resolution: "type-fest@npm:5.4.4"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10c0/bf9c6d7df5383fd720aac71da8ce8690ff1c554459d19cf3c72d61eac98255dba57abe20c628f91f4116f66211791462fdafa90b2be2d7405a5a4c295e4d849d
   languageName: node
   linkType: hard
 
@@ -14264,6 +14208,13 @@ __metadata:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: 10c0/dffbb99329da2aa840f506d376c863bd55f5636f4741ad6e65e82f5ce47e6914108f44f340a0b74009b0cb5d09d6752ae83203e53e98b1192cf80ecee5651636
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.39.1, type-fest@npm:^4.6.0":
+  version: 4.41.0
+  resolution: "type-fest@npm:4.41.0"
+  checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
   languageName: node
   linkType: hard
 
@@ -14592,6 +14543,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"update-browserslist-db@npm:^1.2.0":
+  version: 1.2.3
+  resolution: "update-browserslist-db@npm:1.2.3"
+  dependencies:
+    escalade: "npm:^3.2.0"
+    picocolors: "npm:^1.1.1"
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    update-browserslist-db: cli.js
+  checksum: 10c0/13a00355ea822388f68af57410ce3255941d5fb9b7c49342c4709a07c9f230bbef7f7499ae0ca7e0de532e79a82cc0c4edbd125f1a323a1845bf914efddf8bec
+  languageName: node
+  linkType: hard
+
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
@@ -14614,15 +14579,6 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
-  languageName: node
-  linkType: hard
-
-"uuid@npm:*, uuid@npm:13.0.0":
-  version: 13.0.0
-  resolution: "uuid@npm:13.0.0"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 10c0/950e4c18d57fef6c69675344f5700a08af21e26b9eff2bf2180427564297368c538ea11ac9fb2e6528b17fc3966a9fd2c5049361b0b63c7d654f3c550c9b3d67
   languageName: node
   linkType: hard
 
@@ -14885,10 +14841,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-mimetype@npm:4.0.0":
-  version: 4.0.0
-  resolution: "whatwg-mimetype@npm:4.0.0"
-  checksum: 10c0/a773cdc8126b514d790bdae7052e8bf242970cebd84af62fb2f35a33411e78e981f6c0ab9ed1fe6ec5071b09d5340ac9178e05b52d35a9c4bcf558ba1b1551df
+"whatwg-mimetype@npm:5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-mimetype@npm:5.0.0"
+  checksum: 10c0/eead164fe73a00dd82f817af6fc0bd22e9c273e1d55bf4bc6bdf2da7ad8127fca82ef00ea6a37892f5f5641f8e34128e09508f92126086baba126b9e0d57feb4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 概要

markuplint を v4.14.0 から v5.0.0-alpha.3 にアップグレードし、v5 の新機能・新ルールを導入する。

## 変更内容

### パッケージバージョン更新
- `markuplint`: `4.14.0` → `5.0.0-alpha.3`
- `@markuplint/pug-parser`: `4.6.23` → `5.0.0-alpha.3`

### v5 Named Rule Groups への移行
D-ZERO 独自ルール（`nodeRules`）に `name` プロパティを追加し、v5 の Named Rule Groups 形式に変換。
これにより違反メッセージに `[d-zero/rule-name]` のようなラベルが付与され、どのルールによる違反か特定しやすくなる。

対象ルール:
- `d-zero/html-allow-prefix-attr`
- `d-zero/img-require-alt`
- `d-zero/img-src-kebab-case`
- `d-zero/media-src-kebab-case`
- `d-zero/a-href-convention`
- `d-zero/button-require-command`
- `d-zero/button-prefer-commandfor`
- `d-zero/button-prefer-command-action`
- `d-zero/no-br`（`rules` 内に Named Rule Group として再構成）

### v5 新ルールの追加
recommended プリセットに含まれない以下のルールを採用:

| ルール | 説明 |
|--------|------|
| `attr-order` | 属性順序を `id > class > role > aria-* > data-* > 要素固有属性` に統一 |
| `head-element-order` | `<head>` 内要素の順序を検証 |
| `no-boolean-attr-value` | boolean 属性の冗長な値を禁止（例: `disabled="disabled"`） |
| `no-default-value` | デフォルト値と同一の属性値指定を禁止（例: `type="text"`） |
| `no-use-event-handler-attr` | インラインイベントハンドラ属性を禁止 |
| `no-unsupported-features` | browserslist 設定に基づくブラウザ未サポート要素・属性の検出 |

### img の performance/img-aspect-ratio 無効化
`markuplint:recommended-static-html` の performance プリセットに含まれる `img[src]` に対する `width`/`height` 必須ルールを無効化。
ビルド時に自動付与されるため不要。（v4 では `nodeRules` で上書きしていたが、v5 では `rules` で直接無効化に変更）

### テストの更新
- テスト出力フォーマットに `ruleId` と `name`（Named Rule Group名）を含めるよう変更
- 全フィクスチャファイルの属性順序を `attr-order` ルールに準拠するよう修正
- `no-default-value` ルールにより冗長な `type="text"` を削除
- `attr-order` 専用テストケースを新規追加（正常5パターン + 違反5パターン）
- 全110テストパス確認

### 既知の問題
- `no-unsupported-features` が Node.js v22+ で `@mdn/browser-compat-data` の JSON インポート時にクラッシュする問題あり
  - 上流に Issue 提出済み: https://github.com/markuplint/markuplint/issues/3328
  - browserslist 設定がないプロジェクトでは影響なし（no-op）

## BREAKING CHANGE
markuplint v5 は ARIA 1.3 をデフォルトで使用する。一部の ARIA 属性の検証結果が v4 と異なる場合がある。

## テスト計画
- [x] `yarn test` で全110テストパス
- [x] attr-order テストで正常系・異常系の両方を検証
- [x] Image Naming / Button Command / Extended Naming のテスト期待値更新済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)