### PR TITLE
chore(github): add CODEOWNERS for automatic reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# SEE: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Reviewers
+* @arktds @YusukeHirao


### PR DESCRIPTION
## Summary

`.github/CODEOWNERS` を追加し、PR 作成時に自動でレビュアーがアサインされるようにします。

## 背景

このリポジトリは `.github/CODEOWNERS` が存在しないため、PR を作成してもレビュアーが自動アサインされませんでした（例: #849）。他の管理対象リポジトリ（frontend-env, tools, 等）と同様、CODEOWNERS を配置して自動アサインを有効化します。

## 設定

```
* @arktds @YusukeHirao
```

管理側リポジトリ（`@d-zero`）README の「タグ権限者 (maintain 以上)」と整合する最小構成です。