### PR TITLE
fix(repo): remove duplicate root renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:base"]
-}


### PR DESCRIPTION
## 概要

リポジトリ直下に `renovate.json`（`{"extends":["config:base"]}` のみの薄い内容）と `.github/renovate.json`（automerge の packageRules 等を含む本来の設定）が重複して存在していました。

Renovate は設定ファイルを `renovate.json` → `.github/renovate.json` の順で探索し、最初に見つかったものだけを採用するため、実際に適用されていたのは中身の薄い直下の `renovate.json` であり、`.github/renovate.json` の automerge 設定が無視されていました。これが Renovate の自動マージが機能していなかった原因です。

## 変更内容

- 直下の `renovate.json` を削除
- `.github/renovate.json` が正式な設定として有効になり、automerge（minor/patch/pin/digest の自動マージ）等が機能するようになります

## 確認事項

- `.github/renovate.json` の内容は直下ファイルの設定を包含しており、機能的な後退はありません