### PR TITLE
fix(deps): disable platformAutomerge to keep Renovate direct-merge bypass

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"configMigration": true,
+	"platformAutomerge": false,
 	"extends": [
 		"config:recommended",
 		"docker:pinDigests",


### PR DESCRIPTION
## 概要

`allow_auto_merge` を `false` から `true` に変更したことで、Renovateの挙動が「GitHub native auto-merge予約」方式に切り替わってしまい、重大な退行が発生していました。

## 問題

- ブランチ保護(dev)では `required_approving_review_count: 2` が設定されているが、`bypass_pull_request_allowances` にRenovate app(login: renovate)が登録されているため、本来Renovateは自身のREST/GraphQL directマージAPIでレビュー要件をバイパスして自動マージできるはずでした。
- しかし `allow_auto_merge: true` にした結果、Renovateが「GitHub native auto-merge予約」方式を使うようになりました。native auto-merge予約はブランチ保護の `bypass_pull_request_allowances` を評価せず、レビュー必須要件がそのまま適用されてしまいます。
- この結果、CIが完全に成功しているPR(#858, #859, #860, #861, #855, #856, #857, #827など)がauto-merge予約されたまま `mergeStateStatus: BLOCKED`、`reviewDecision: REVIEW_REQUIRED` の状態で何十分経ってもマージされない、という詰まりが発生することを確認しました。

## 対応

Renovateの `platformAutomerge` を明示的に `false` に設定し、`allow_auto_merge` の値に関わらずRenovateが常に自前のdirectマージAPI（bypassが効く方式）を使うように固定しました。これが根本解決策です。

## 変更内容

- `.github/renovate.json` のトップレベルに `"platformAutomerge": false` を追加(既存の `packageRules` 内のautomerge設定はそのまま維持)

## 検証

- `npx vitest run` — 全135テスト成功
- 各パッケージの `tsc` ビルド — 全て成功
- `npx eslint` — エラーなし
- `npx prettier --check` — フォーマット問題なし