### PR TITLE
chore(repo): upgrade Node.js to v26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Enable Corepack and setup Yarn v4
         run: |
+          npm install -g corepack --force
           corepack enable
           yarn --version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, windows-latest]
-        node: [24]
+        node: [26]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - dev
+      - 'v*'
 
 jobs:
   test:

--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,6 @@
 {
 	"import": ["@d-zero/cspell-config"],
-	"ignorePaths": ["**/.*/**", "**/CODEOWNERS"],
+	"ignorePaths": ["**/.[!.]*/**", "**/CODEOWNERS"],
 	"words": [
 		//
 		"unspaced",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 	},
 	"packageManager": "yarn@4.18.0",
 	"volta": {
-		"node": "24.19.0",
+		"node": "26.6.0",
 		"yarn": "4.18.0"
 	}
 }


### PR DESCRIPTION
## Summary
- Upgrade development/CI Node.js to v26 (Volta `node` pinned to `26.6.0`, CI matrix `node: [24]` → `[26]`)
- Fix a pre-existing cspell bug carried over from `v6`: cspell 10's glob engine resolves `"**/.*/**"` to match a bare `.`, making it equivalent to `"**/**"` and excluding every file (`lint:cspell` was silently checking 0 files). Changed to `"**/.[!.]*/**"`.

## Test plan
- [x] `yarn install` on Node.js 26.6.0
- [x] `yarn build`
- [x] `yarn lint` (0 errors; 2 pre-existing jsdoc warnings unrelated to this change)
- [x] `yarn test` (135 tests passed)
